### PR TITLE
Fixes for cysignal and python3

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+jobs="-j 4 "
+if [ "$1" = "-j" ]; then
+   jobs="-j $2 "
+fi
+
 # Create Virtual Environment
 
 rm -rf g6k-env
@@ -35,7 +40,7 @@ cd g6k-fplll || exit
 ./autogen.sh
 ./configure --prefix="$VIRTUAL_ENV" $CONFIGURE_FLAGS
 make clean
-make -j 4
+make $jobs
 make install
 cd ..
 
@@ -46,13 +51,14 @@ pip install Cython
 pip install -r requirements.txt
 pip install -r suggestions.txt
 python setup.py clean
-python setup.py build_ext
+python setup.py build_ext $jobs
 python setup.py install
 cd ..
 
 pip install -r requirements.txt
 python setup.py clean
-python setup.py build_ext --inplace
+python setup.py build_ext $jobs --inplace
 
+echo " "
 echo "Don't forget to activate environment each time:"
 echo " source ./activate"

--- a/bootstrap3.sh
+++ b/bootstrap3.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+
+jobs="-j 4 "
+if [ "$1" = "-j" ]; then
+   jobs="-j $2 "
+fi
+
 # Create Virtual Environment
 alias python=/usr/bin/python3
 alias pip=/usr/bin/pip3
@@ -45,7 +51,7 @@ cd g6k-fplll || exit
 ./autogen.sh
 ./configure --prefix="$VIRTUAL_ENV" $CONFIGURE_FLAGS
 make clean
-make -j 4
+make $jobs
 make install
 cd ..
 
@@ -56,13 +62,13 @@ pip install Cython
 pip install -r requirements.txt
 pip install -r suggestions.txt
 python setup.py clean
-python setup.py build_ext
+python setup.py build_ext $jobs
 python setup.py install
 cd ..
 
 pip install -r requirements.txt
 python setup.py clean
-python setup.py build_ext --inplace
+python setup.py build_ext $jobs --inplace
 
 echo "Don't forget to activate environment each time:"
 echo " source ./activate"

--- a/bootstrap3.sh
+++ b/bootstrap3.sh
@@ -1,11 +1,8 @@
 #!/usr/bin/env bash
 
-jobs="-j 4 "
-if [ "$1" = "-j" ]; then
-   jobs="-j $2 "
-fi
-
 # Create Virtual Environment
+alias python=/usr/bin/python3
+alias pip=/usr/bin/pip3
 
 rm -rf g6k-env
 virtualenv g6k-env
@@ -48,7 +45,7 @@ cd g6k-fplll || exit
 ./autogen.sh
 ./configure --prefix="$VIRTUAL_ENV" $CONFIGURE_FLAGS
 make clean
-make $jobs
+make -j 4
 make install
 cd ..
 
@@ -59,14 +56,13 @@ pip install Cython
 pip install -r requirements.txt
 pip install -r suggestions.txt
 python setup.py clean
-python setup.py build_ext $jobs
+python setup.py build_ext
 python setup.py install
 cd ..
 
 pip install -r requirements.txt
 python setup.py clean
-python setup.py build_ext $jobs --inplace
+python setup.py build_ext --inplace
 
-echo " "
 echo "Don't forget to activate environment each time:"
 echo " source ./activate"

--- a/rebuild.sh
+++ b/rebuild.sh
@@ -5,8 +5,8 @@ enable_stats=0
 enable_ndebug=0
 maxsievingdim=128
 enable_ggdb=0
-enable_jobs=0
 enable_templated_dim=0
+jobs=4
 
 while [[ $# -gt 0 ]]; do
 	case "$1" in
@@ -15,7 +15,8 @@ while [[ $# -gt 0 ]]; do
 			shift
 			;;
 		-j|--jobs)
-			enable_jobs=1
+			jobs=$2
+			shift
 			;;
 		-g|--ggdb)
 			enable_ggdb=1
@@ -82,18 +83,9 @@ if [ "$sieve_threshold" != "" ]; then
 fi
 export EXTRAFLAGS
 
-if [ ${enable_jobs} -eq 0 ]; then
-	make -C kernel clean || exit 1
-	make -C kernel
-fi
-
-if [ ${enable_jobs} -eq 1 ]; then
-	make -C kernel clean || exit 1
-	make -j -C kernel
-fi
-
-
+make -C kernel clean || exit 1
+make -C kernel -j ${jobs}
 
 rm g6k/siever.so `find g6k -name "*.pyc"`
 python setup.py clean
-python setup.py build_ext --inplace || exit 1
+python setup.py build_ext -j ${jobs} --inplace || exit 1


### PR DESCRIPTION
Avoid issue with cysignals by only setting up compilation flag after its installation.
Plus a bootstrap3.sh variant that force python=python3 for the transitional period.