### PR TITLE
Parallel

### DIFF
--- a/kernel/bgj1_sieve.cpp
+++ b/kernel/bgj1_sieve.cpp
@@ -479,14 +479,14 @@ bool Siever::bgj1_execute_delayed_replace(std::vector<Entry>& transaction_db, bo
     size_t improvindex = params.bgj1_improvement_db_ratio * (cdb.size()-1);
     if (params.threads == 1)
     {
-        std::sort(cdb.begin()+GBL_replace_pos+1, cdb.end(), &compare_CE);
-        std::inplace_merge(cdb.begin(), cdb.begin()+GBL_replace_pos+1, cdb.end(), &compare_CE);
+        std::sort(cdb.begin()+GBL_replace_pos+1, cdb.end(), compare_CE());
+        std::inplace_merge(cdb.begin(), cdb.begin()+GBL_replace_pos+1, cdb.end(), compare_CE());
     }
     else
     {
         bgj1_cdb_copy=cdb;
-        std::sort(bgj1_cdb_copy.begin()+GBL_replace_pos+1, bgj1_cdb_copy.end(), &compare_CE);
-        std::inplace_merge(bgj1_cdb_copy.begin(), bgj1_cdb_copy.begin()+GBL_replace_pos+1, bgj1_cdb_copy.end(), &compare_CE);
+        std::sort(bgj1_cdb_copy.begin()+GBL_replace_pos+1, bgj1_cdb_copy.end(), compare_CE());
+        std::inplace_merge(bgj1_cdb_copy.begin(), bgj1_cdb_copy.begin()+GBL_replace_pos+1, bgj1_cdb_copy.end(), compare_CE());
         cdb.swap(bgj1_cdb_copy);
         GBL_start_of_cdb_ptr = &(cdb.front());
     }

--- a/kernel/bgj1_sieve.cpp
+++ b/kernel/bgj1_sieve.cpp
@@ -484,10 +484,10 @@ bool Siever::bgj1_execute_delayed_replace(std::vector<Entry>& transaction_db, bo
     }
     else
     {
-        bgj1_cdb_copy=cdb;
-        std::sort(bgj1_cdb_copy.begin()+GBL_replace_pos+1, bgj1_cdb_copy.end(), compare_CE());
-        std::inplace_merge(bgj1_cdb_copy.begin(), bgj1_cdb_copy.begin()+GBL_replace_pos+1, bgj1_cdb_copy.end(), compare_CE());
-        cdb.swap(bgj1_cdb_copy);
+        cdb_tmp_copy=cdb;
+        std::sort(cdb_tmp_copy.begin()+GBL_replace_pos+1, cdb_tmp_copy.end(), compare_CE());
+        std::inplace_merge(cdb_tmp_copy.begin(), cdb_tmp_copy.begin()+GBL_replace_pos+1, cdb_tmp_copy.end(), compare_CE());
+        cdb.swap(cdb_tmp_copy);
         GBL_start_of_cdb_ptr = &(cdb.front());
     }
     statistics.inc_stats_sorting_sieve();

--- a/kernel/control.cpp
+++ b/kernel/control.cpp
@@ -2,14 +2,19 @@
 #include <mutex>
 #include "siever.h"
 
+#include "parallel_algorithms.hpp"
+namespace pa = parallel_algorithms;
+
 // reserves size for db and cdb. If called with a larger size than the current capacities, does nothing
 void Siever::reserve(size_t const reserved_db_size)
 {
     CPUCOUNT(216);
     db.reserve(reserved_db_size);
     cdb.reserve(reserved_db_size);
-    // bgj1_cdb_copy is only needed for bgj1. We delay the reservation until we need it.
-    if( sieve_status == SieveStatus::bgj1 ) bgj1_cdb_copy.reserve(reserved_db_size);
+    // old: bgj1_cdb_copy is only needed for bgj1. We delay the reservation until we need it.
+    // old: if( sieve_status == SieveStatus::bgj1 )
+    // new: bgj1_cdb_copy is also used in parallel_sort_cdb and other functions
+    bgj1_cdb_copy.reserve(reserved_db_size);
 }
 
 // switches the current sieve_status to the new one and updates internal data accordingly.
@@ -23,11 +28,14 @@ bool Siever::switch_mode_to(Siever::SieveStatus new_sieve_status)
     {
         return false;
     }
+    bgj1_cdb_copy.reserve(db.capacity());
+    cdb.reserve(db.capacity());
     switch(new_sieve_status)
     {
         case SieveStatus::bgj1 :
             bgj1_cdb_copy.reserve(db.capacity());
             [[fallthrough]];
+
         case SieveStatus::plain :
             if(sieve_status == SieveStatus::gauss || sieve_status == SieveStatus::triple_mt)
             {
@@ -36,11 +44,15 @@ bool Siever::switch_mode_to(Siever::SieveStatus new_sieve_status)
                 assert(data.list_sorted_until <= data.queue_start);
                 assert(data.queue_start       <= data.queue_sorted_until);
                 assert(data.queue_sorted_until<= db_size() );
-                assert(std::is_sorted(cdb.cbegin(),cdb.cbegin()+data.list_sorted_until, &compare_CE  ) );
-                assert(std::is_sorted(cdb.cbegin()+data.queue_start, cdb.cbegin() + data.queue_sorted_until , &compare_CE  ));
+                assert(std::is_sorted(cdb.cbegin(),cdb.cbegin()+data.list_sorted_until, compare_CE()  ) );
+                assert(std::is_sorted(cdb.cbegin()+data.queue_start, cdb.cbegin() + data.queue_sorted_until , compare_CE()  ));
+
                 if(data.list_sorted_until == data.queue_start)
                 {
-                    std::inplace_merge(cdb.begin(), cdb.begin()+ data.queue_start, cdb.begin()+ data.queue_sorted_until, &compare_CE);
+                    bgj1_cdb_copy.resize(cdb.size());
+                    pa::merge(cdb.begin(), cdb.begin()+data.queue_start, cdb.begin()+data.queue_start, cdb.begin()+data.queue_sorted_until, bgj1_cdb_copy.begin(), compare_CE(), threadpool);
+                    pa::copy(cdb.begin()+data.queue_sorted_until, cdb.end(), bgj1_cdb_copy.begin()+data.queue_sorted_until, threadpool);
+                    cdb.swap(bgj1_cdb_copy);
                     new_status_data.plain_data.sorted_until =  data.queue_sorted_until;
                 }
                 else
@@ -52,6 +64,7 @@ bool Siever::switch_mode_to(Siever::SieveStatus new_sieve_status)
             // switching between bgj1 and plain does nothing, essentially.
             sieve_status = new_sieve_status;
             break;
+
         // switching from gauss to triple_mt and vice-versa is ill-supported (it works, but it throws away work)
         case SieveStatus::gauss :
             [[fallthrough]];
@@ -60,7 +73,7 @@ bool Siever::switch_mode_to(Siever::SieveStatus new_sieve_status)
             {
                 StatusData::Plain_Data &data = status_data.plain_data;
                 assert(data.sorted_until <= cdb.size());
-                assert(std::is_sorted(cdb.cbegin(), cdb.cbegin() + data.sorted_until, &compare_CE ));
+                assert(std::is_sorted(cdb.cbegin(), cdb.cbegin() + data.sorted_until, compare_CE() ));
                 StatusData new_status_data;
                 new_status_data.gauss_data.list_sorted_until = 0;
                 new_status_data.gauss_data.queue_start = 0;
@@ -326,7 +339,7 @@ void Siever::gso_update_postprocessing_task(size_t const start, size_t const end
     assert(n_old == (tnold < 0 ? n_old : tnold));
     std::array<ZT,MAX_SIEVING_DIM> x_new; // create one copy on the stack to avoid reallocating memory inside the loop.
 
-    for(size_t i = start; i < end; ++i)
+    for (size_t i = start; i < end; ++i)
     {
         std::fill(x_new.begin(), x_new.end(), 0);
         for(unsigned int j = 0; j < n; ++j)
@@ -382,14 +395,12 @@ void Siever::gso_update_postprocessing(const unsigned int l_, const unsigned int
     UNTEMPLATE_DIM(&Siever::gso_update_postprocessing_task, task, n_old);
 
     size_t const th_n = std::min(params.threads, static_cast<size_t>(1 + db.size() / MIN_ENTRY_PER_THREAD));
-
-    for (size_t c = 0; c < th_n; ++c)
-    {
-        threadpool.push( [this, th_n, task, c, &MT, n_old]()
-            { ((*this).*task)( (c*this->db.size())/th_n, ((c+1)*this->db.size())/th_n, n_old, MT); }
-          );
-    }
-    threadpool.wait_work();
+    threadpool.run(
+        [this, task, MT, n_old](int th_i, int th_n)
+        {
+            pa::subrange subrange(this->db.size(), th_i, th_n);
+            ((*this).*task)(subrange.first(), subrange.last(), n_old, MT);
+        }, th_n);
     invalidate_sorting();
     invalidate_histo();
     refresh_db_collision_checks();
@@ -479,21 +490,8 @@ void Siever::best_lifts(long* vecs, double* lens)
     }
 }
 
-void Siever::shrink_db_task(size_t const start, size_t const end, 
-                                std::vector<IT>& to_save, std::vector<IT>& to_kill) 
-{
-    for (size_t i = start; i < end; ++i)
-    {
-        size_t kill_i = cdb[to_kill[i]].i;
-        size_t save_i = cdb[to_save[i]].i;
-        uid_hash_table.erase_uid(db[kill_i].uid);
-        db[kill_i] = db[save_i];
-        cdb[to_save[i]].i = kill_i;
-    }    
-}
-
 // sorts cdb and only keeps the best N vectors.
-void Siever::shrink_db(unsigned long N)
+void Siever::shrink_db(unsigned long N, bool erase_uid)
 {
 
     CPUCOUNT(207);
@@ -513,29 +511,71 @@ void Siever::shrink_db(unsigned long N)
 
     std::vector<IT> to_save;
     std::vector<IT> to_kill;
+    to_save.resize(cdb.size()-N);
+    to_kill.resize(cdb.size()-N);
+    std::atomic_size_t to_save_size(0), to_kill_size(0);
 
-    to_save.reserve(cdb.size() - N);
-    to_kill.reserve(cdb.size() - N);
+    threadpool.run([this,N,&to_save,&to_kill,&to_save_size,&to_kill_size,erase_uid]
+        (int th_i, int th_n)
+        {
+            pa::subrange lowrange(0, N, th_i, th_n), highrange(N, cdb.size(), th_i, th_n);
+            auto l_it = this->cdb.begin() + lowrange.first(), l_end = this->cdb.begin() + lowrange.last();
+            auto h_it = this->cdb.begin() + highrange.first(), h_end = this->cdb.begin() + highrange.last();
+            // scan ranges and performs swaps on the fly
+            for (; l_it != l_end; ++l_it)
+            {
+                if (l_it->i < N)
+                    continue;
+                for (; h_it != h_end && h_it->i >= N; ++h_it)
+                    ;
+                if (h_it == h_end)
+                    break;
+                if (erase_uid)
+                    uid_hash_table.erase_uid(db[l_it->i].uid);
+                db[l_it->i] = db[h_it->i];
+                std::swap(l_it->i, h_it->i);
+                ++h_it;
+            }
+            // remaining parts have to be saved
+            std::vector<IT> tmpbuf;
+            for (; l_it != l_end; ++l_it)
+            {
+                if (l_it->i < N)
+                    continue;
+                tmpbuf.emplace_back(l_it - this->cdb.begin());
+            }
+            size_t w_idx = to_kill_size.fetch_add(tmpbuf.size());
+            std::copy(tmpbuf.begin(), tmpbuf.end(), to_kill.begin()+w_idx);
+            tmpbuf.clear();
 
-    for (size_t i = 0; i < N; ++i){
-        if (cdb[i].i >= N) to_save.push_back(i);
-    }
-
-    for (size_t i = N; i < cdb.size(); ++i){
-        if (cdb[i].i < N) to_kill.push_back(i);
-    }
-
-    size_t swaps = to_save.size();
-    assert(to_kill.size() == swaps);
-
-    size_t const th_n = std::min(params.threads, static_cast<size_t>(1 + swaps / MIN_ENTRY_PER_THREAD));
-    for (size_t c = 0; c < th_n; ++c)
-    {
-        threadpool.push( [this, th_n, swaps, c, &to_save, &to_kill]()
-            { this->shrink_db_task( (c*swaps)/th_n, ((c+1)*swaps)/th_n, to_save, to_kill); }
-          );
-    }
-    threadpool.wait_work();
+            for (; h_it != h_end; ++h_it)
+            {
+                if (h_it->i >= N)
+                {
+                    if (erase_uid)
+                        uid_hash_table.erase_uid(db[h_it->i].uid);
+                    continue;
+                }
+                tmpbuf.emplace_back(h_it - this->cdb.begin());
+            }
+            w_idx = to_save_size.fetch_add(tmpbuf.size());
+            std::copy(tmpbuf.begin(), tmpbuf.end(), to_save.begin()+w_idx);
+            tmpbuf.clear();
+        });
+    assert(to_kill_size == to_save_size);
+    threadpool.run([this,&to_save,&to_kill,&to_save_size,&to_kill_size,erase_uid](int th_i, int th_n)
+        {
+            std::size_t size = to_save_size;
+            pa::subrange subrange(size, th_i, th_n);
+            for (auto j : subrange)
+            {
+                std::size_t k = to_kill[j], s = to_save[j];
+                if (erase_uid)
+                    uid_hash_table.erase_uid( db[ cdb[k].i ].uid );
+                db[ cdb[k].i ] = db[ cdb[s].i ];
+                std::swap(cdb[k].i, cdb[s].i);
+            }
+        });
 
     cdb.resize(N);
     db.resize(N);
@@ -555,31 +595,18 @@ void Siever::parallel_sort_cdb()
     {
         StatusData::Plain_Data &data = status_data.plain_data;
         assert(data.sorted_until <= cdb.size());
-        assert(std::is_sorted(cdb.cbegin(), cdb.cbegin() + data.sorted_until, &compare_CE  ));
+        assert(std::is_sorted(cdb.cbegin(), cdb.cbegin() + data.sorted_until, compare_CE()  ));
         if(data.sorted_until == cdb.size())
         {
             return; // nothing to do. We do not increase the statistics counter.
         }
 
-        // size of the unsorted part of cdb.
-        size_t const size_left = cdb.size() - data.sorted_until;
-        auto const start_unsorted = cdb.begin() + data.sorted_until;
-
-        // number of threads we wish to have.
-        size_t const th_n = std::min( params.threads, static_cast<size_t>(1 + size_left / (10 * MIN_ENTRY_PER_THREAD)));
-
-        for (size_t c = 0; c < th_n; ++c)
-        {
-            size_t N0 = (size_left * c) / th_n;
-            size_t N1 = (size_left * (c+1)) / th_n;
-            assert( (c < th_n) || (N1 == size_left) );
-            if (c+1 < th_n) std::nth_element(start_unsorted+N0, start_unsorted+N1, cdb.end(), &compare_CE);
-            threadpool.push([N0,N1,start_unsorted](){ std::sort(start_unsorted+N0, start_unsorted+N1, &compare_CE) ;});
-        }
-        threadpool.wait_work();
-        std::inplace_merge(cdb.begin(), start_unsorted, cdb.end(), &compare_CE);
+        pa::sort(cdb.begin()+data.sorted_until, cdb.end(), compare_CE(), threadpool);
+        bgj1_cdb_copy.resize(cdb.size());
+        pa::merge(cdb.begin(), cdb.begin()+data.sorted_until, cdb.begin()+data.sorted_until, cdb.end(), bgj1_cdb_copy.begin(), compare_CE(), threadpool);
+        cdb.swap(bgj1_cdb_copy);
         data.sorted_until = cdb.size();
-        assert(std::is_sorted(cdb.cbegin(), cdb.cend(), &compare_CE ));
+        assert(std::is_sorted(cdb.cbegin(), cdb.cend(), compare_CE() ));
         // TODO: statistics.inc_stats_sorting_overhead();
         return;
     }
@@ -589,8 +616,8 @@ void Siever::parallel_sort_cdb()
         assert(data.list_sorted_until <= data.queue_start);
         assert(data.queue_start <= data.queue_sorted_until);
         assert(data.queue_sorted_until <= cdb.size());
-        assert(std::is_sorted(cdb.cbegin(), cdb.cbegin()+ data.list_sorted_until, &compare_CE )  );
-        assert(std::is_sorted(cdb.cbegin()+ data.queue_start, cdb.cbegin() + data.queue_sorted_until, &compare_CE ));
+        assert(std::is_sorted(cdb.cbegin(), cdb.cbegin()+ data.list_sorted_until, compare_CE() )  );
+        assert(std::is_sorted(cdb.cbegin()+ data.queue_start, cdb.cbegin() + data.queue_sorted_until, compare_CE() ));
         size_t const unsorted_list_left = data.queue_start - data.list_sorted_until;
         size_t const unsorted_queue_left = cdb.size() - data.queue_sorted_until;
         if ( (unsorted_list_left == 0) && (unsorted_queue_left == 0))
@@ -605,50 +632,49 @@ void Siever::parallel_sort_cdb()
         if (unsorted_queue_left > 0 && max_threads_queue == 0)
             max_threads_queue = 1;
 
-        if(unsorted_list_left > 0)
+        if (unsorted_list_left > 0 && unsorted_queue_left > 0)
         {
-            auto const start_unsorted = cdb.begin() + data.list_sorted_until;
-            auto const end_unsorted   = cdb.begin() + data.queue_start;
-            size_t const th_n_list = std::min(max_threads_list, static_cast<size_t>(1+ unsorted_list_left / (10* MIN_ENTRY_PER_THREAD)));
-            for(size_t c = 0; c < th_n_list; ++c)
-            {
-                size_t const N0 = (unsorted_list_left * c) / th_n_list;
-                size_t const N1 = (unsorted_list_left * (c+1)) / th_n_list;
-                assert( (c < th_n_list) || (N1 == unsorted_list_left) );
-                if( c + 1 < th_n_list) std::nth_element(start_unsorted + N0, start_unsorted + N1, end_unsorted, &compare_CE);
-                threadpool.push([N0,N1,start_unsorted](){ std::sort(start_unsorted+N0, start_unsorted+N1, &compare_CE) ;});
-            }
-            if(params.threads == 1 && unsorted_queue_left > 0)
-                threadpool.wait_work();
+            // list range : [0, data.queue_start) of which [0, data.list_sorted_until) is sorted
+            bgj1_cdb_copy.resize(cdb.size());
+            pa::sort(cdb.begin() + data.list_sorted_until, cdb.begin() + data.queue_start, compare_CE(), threadpool);
+            pa::merge(cdb.begin(), cdb.begin() + data.list_sorted_until, cdb.begin() + data.list_sorted_until, cdb.begin() + data.queue_start, bgj1_cdb_copy.begin(), compare_CE(), threadpool);
+            // queue range: [data.queue_start, end) of which [data.queue_start, data.queue_sorted_until) is sorted
+            pa::sort(cdb.begin() + data.queue_sorted_until, cdb.end(), compare_CE(), threadpool);
+            pa::merge(cdb.begin() + data.queue_start, cdb.begin() + data.queue_sorted_until, cdb.begin() + data.queue_sorted_until, cdb.end(), bgj1_cdb_copy.begin()+data.queue_start, compare_CE(), threadpool);
+            cdb.swap(bgj1_cdb_copy);
         }
-        if(unsorted_queue_left > 0)
+        else if (unsorted_list_left > 0)
         {
-            auto const start_unsorted = cdb.begin() + data.queue_sorted_until; // start of range to sort
-            auto const end_unsorted   = cdb.end(); // end of range to sort
-            size_t const th_n_queue = std::min(max_threads_queue, static_cast<size_t>(1 + unsorted_queue_left / (10 * MIN_ENTRY_PER_THREAD )));
-            for(size_t c = 0; c < th_n_queue; ++c)
+            // list range : [0, data.queue_start) of which [0, data.list_sorted_until) is sorted
+            bgj1_cdb_copy.resize(cdb.size());
+            pa::sort(cdb.begin() + data.list_sorted_until, cdb.begin() + data.queue_start, compare_CE(), threadpool);
+            pa::merge(cdb.begin(), cdb.begin() + data.list_sorted_until, cdb.begin() + data.list_sorted_until, cdb.begin() + data.queue_start, bgj1_cdb_copy.begin(), compare_CE(), threadpool);
+            if (data.queue_start < cdb.size()/2)
+                pa::copy(bgj1_cdb_copy.begin(), bgj1_cdb_copy.begin()+data.queue_start, cdb.begin(), threadpool);
+            else
             {
-                size_t const N0 = (unsorted_queue_left * c) / th_n_queue;
-                size_t const N1 = (unsorted_queue_left  * (c+1)) / th_n_queue;
-                assert( (c < th_n_queue) || (N1 == unsorted_queue_left) );
-                if ( c + 1 < th_n_queue) std::nth_element(start_unsorted + N0, start_unsorted + N1, end_unsorted, &compare_CE);
-                threadpool.push([N0, N1, start_unsorted]() {std::sort(start_unsorted+N0, start_unsorted+N1, &compare_CE); } );
+                pa::copy(cdb.begin()+data.queue_start, cdb.end(), bgj1_cdb_copy.begin()+data.queue_start, threadpool);
+                cdb.swap(bgj1_cdb_copy);
             }
         }
-        threadpool.wait_work();
-        if(data.list_sorted_until > 0)
+        else if (unsorted_queue_left > 0)
         {
-            threadpool.push([this, &data]{std::inplace_merge(cdb.begin(), cdb.begin() + data.list_sorted_until, cdb.begin() + data.queue_start, &compare_CE); }  );
-            if(params.threads == 1)
-                threadpool.wait_work();
+            // list range : [0, data.queue_start) of which [0, data.list_sorted_until) is sorted
+            bgj1_cdb_copy.resize(cdb.size());
+            // queue range: [data.queue_start, end) of which [data.queue_start, data.queue_sorted_until) is sorted
+            pa::sort(cdb.begin() + data.queue_sorted_until, cdb.end(), compare_CE(), threadpool);
+            pa::merge(cdb.begin() + data.queue_start, cdb.begin() + data.queue_sorted_until, cdb.begin() + data.queue_sorted_until, cdb.end(), bgj1_cdb_copy.begin()+data.queue_start, compare_CE(), threadpool);
+            if (data.queue_start > cdb.size()/2)
+                pa::copy(bgj1_cdb_copy.begin() + data.queue_start, bgj1_cdb_copy.end() + data.queue_start, cdb.begin()+data.queue_start, threadpool);
+            else
+            {
+                pa::copy(cdb.begin(), cdb.begin()+data.queue_start, bgj1_cdb_copy.begin(), threadpool);
+                cdb.swap(bgj1_cdb_copy);
+            }
         }
-        if(data.queue_sorted_until >  data.queue_start)
-        {
-            threadpool.push([this, &data]{std::inplace_merge(cdb.begin()+ data.queue_start, cdb.begin() + data.queue_sorted_until, cdb.end(), &compare_CE);}  );
-        }
-        threadpool.wait_work();
-        assert(std::is_sorted(cdb.cbegin(), cdb.cbegin() + data.queue_start, &compare_CE  ));
-        assert(std::is_sorted(cdb.cbegin()+ data.queue_start, cdb.cend(), &compare_CE  ));
+        assert(1==0);
+//        assert(std::is_sorted(cdb.cbegin(), cdb.cbegin() + data.queue_start, compare_CE()  ));
+//        assert(std::is_sorted(cdb.cbegin()+ data.queue_start, cdb.cend(), compare_CE()  ));
         data.list_sorted_until = data.queue_start;
         data.queue_sorted_until = cdb.size();
         return;

--- a/kernel/control.cpp
+++ b/kernel/control.cpp
@@ -672,7 +672,6 @@ void Siever::parallel_sort_cdb()
                 cdb.swap(bgj1_cdb_copy);
             }
         }
-        assert(1==0);
 //        assert(std::is_sorted(cdb.cbegin(), cdb.cbegin() + data.queue_start, compare_CE()  ));
 //        assert(std::is_sorted(cdb.cbegin()+ data.queue_start, cdb.cend(), compare_CE()  ));
         data.list_sorted_until = data.queue_start;

--- a/kernel/parallel_algorithms.hpp
+++ b/kernel/parallel_algorithms.hpp
@@ -1,0 +1,607 @@
+/***************************************************************************************\
+*                                                                                      *
+* https://github.com/cr-marcstevens/snippets/tree/master/cxxheaderonly                 *
+*                                                                                      *
+* parallel_algorithms.hpp - A header only C++ light-weight parallel algorithms library *
+* Copyright (c) 2020 Marc Stevens                                                      *
+*                                                                                      *
+* MIT License                                                                          *
+*                                                                                      *
+* Permission is hereby granted, free of charge, to any person obtaining a copy         *
+* of this software and associated documentation files (the "Software"), to deal        *
+* in the Software without restriction, including without limitation the rights         *
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell            *
+* copies of the Software, and to permit persons to whom the Software is                *
+* furnished to do so, subject to the following conditions:                             *
+*                                                                                      *
+* The above copyright notice and this permission notice shall be included in all       *
+* copies or substantial portions of the Software.                                      *
+*                                                                                      *
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR           *
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,             *
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE          *
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER               *
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,        *
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE        *
+* SOFTWARE.                                                                            *
+*                                                                                      *
+\**************************************************************************************/
+
+#ifndef PARALLEL_ALGORITHMS_HPP
+#define PARALLEL_ALGORITHMS_HPP
+
+#include "thread_pool.hpp"
+#include <cassert>
+
+/*************************** example usage ***************************************\
+grep "^//test.cpp" parallel_algoritms.hpp -A34 > test.cpp
+g++ -std=c++11 -o test test.cpp -pthread -lpthread
+
+//test.cpp:
+#include "thread_pool.hpp"
+#include <iostream>
+
+int main()
+{
+	// use main thread also as worker using wait_work(), so init 1 less in thread pool
+	// (alternatively use wait_sleep() and make threads for all logical hardware cores)
+    thread_pool::thread_pool tp(std::thread::hardware_concurrency() - 1);
+
+}
+
+\************************* end example usage *************************************/
+
+namespace parallel_algorithms {
+
+#ifndef PA_PARTITION_CHUNKSIZE
+#define PA_PARTITION_CHUNKSIZE   2048
+#endif
+#ifndef PA_NTH_ELEMENT_CHUNKSIZE
+#define PA_NTH_ELEMENT_CHUNKSIZE 2048
+#endif
+#ifndef PA_SORT_CHUNKSIZE
+#define PA_SORT_CHUNKSIZE        2048
+#endif
+
+	/*
+		// basic iterator: an std::size_t integer that behaves as an iterator
+		class range_iterator {
+		public:
+			range_iterator(std::size_t i = 0);
+			// comparison operators: == != < <= > >=
+			// reference operators : * -> []
+			// add / sub           : ++ ++(int) -- --(int) + - += -=
+		};
+	*/
+	/*
+		// represents the i-th subrange of a range divides into n equal size range
+		class subrange {
+		public:
+			subrange(std::size_t first, std::size_t last, std::size_t i, std::size_t n); // for range [first,last)
+			subrange(std::size_t size = 0, std::size_t i = 0, std::size_t n = 1);        // for range [0, size)
+			range_iterator begin(); // iterator to begin of subrange
+			range_iterator end();   // iterator to end of subrange
+			std::size_t first();    // index of begin of subrange
+			std::size_t last();     // index of end of subrange
+		};
+	*/
+	/*
+		// behaves as std::partition(first, last, Pred) in a parallel implementation using a given threadpool
+		template<typename RandIt, typename Pred, typename Threadpool>
+		RandIt partition(RandIt first, RandIt last, Pred pred, Threadpool& threadpool, const std::size_t chunksize = PA_PARTITION_CHUNKSIZE);
+	*/
+	/*
+		// behaves as std::nth_element(first, nth, last, cf) in a parallel implementation using a given threadpool
+		template<typename RandIt, typename Compare, typename Threadpool>
+		void nth_element(RandIt first, RandIt nth, RandIt last, Compare cf, Threadpool& threadpool, std::size_t chunksize = PA_NTH_ELEMENT_CHUNKSIZE);
+
+		// behaves as std::nth_element(first, nth, last) in a parallel implementation using a given threadpool
+		template<typename RandIt, typename Threadpool>
+		void nth_element(RandIt first, RandIt nth, RandIt last, Threadpool& threadpool, std::size_t chunksize = PA_NTH_ELEMENT_CHUNKSIZE);
+	*/
+	/*
+		// behaves as std::merge(first1, last1, first2, last2, dest, cf) in a parallel implementation using a given threadpool
+		template<typename RandIt1, typename RandIt2, typename OutputIt, typename Compare, typename Threadpool>
+		OutputIt merge(RandIt1 first1, RandIt1 last1, RandIt2 first2, RandIt2 last2, OutputIt dest, Compare cf, Threadpool& threadpool);
+
+		// behaves as std::merge(first1, last1, first2, last2, dest) in a parallel implementation using a given threadpool
+		template<typename RandIt1, typename RandIt2, typename OutputIt, typename Threadpool>
+		OutputIt merge(RandIt1 first1, RandIt1 last1, RandIt2 first2, RandIt2 last2, OutputIt dest, Threadpool& threadpool);
+	*/
+	/*
+		// behaves as std::sort(first, last, cf) in a parallel implementation using a given threadpool
+		template<typename RandIt, typename Compare, typename Threadpool>
+		void sort(RandIt first, RandIt last, Compare cf, Threadpool& threadpool, const std::size_t chunksize = PA_SORT_CHUNKSIZE);
+
+		// behaves as std::sort(first, last) in a parallel implementation using a given threadpool
+		template<typename RandIt, typename Threadpool>
+		void sort(RandIt first, RandIt last, Threadpool& threadpool, const std::size_t chunksize = PA_SORT_CHUNKSIZE);
+	*/
+
+
+	// basic iterator: an std::size_t integer that behaves as an iterator
+	class range_iterator
+		: public std::iterator<std::random_access_iterator_tag, const std::size_t>
+	{
+		std::size_t _i;
+
+	public:
+		range_iterator(std::size_t i = 0): _i(i) {}
+
+		bool operator== (const range_iterator& r) const { return _i == r._i; }
+		bool operator!= (const range_iterator& r) const { return _i != r._i; }
+		bool operator<  (const range_iterator& r) const { return _i <  r._i; }
+		bool operator<= (const range_iterator& r) const { return _i <= r._i; }
+		bool operator>  (const range_iterator& r) const { return _i >  r._i; }
+		bool operator>= (const range_iterator& r) const { return _i >= r._i; }
+		
+		const std::size_t operator*() const { return _i; }
+		const std::size_t* operator->() const { return &_i; }
+		const std::size_t operator[](std::size_t n) const { return _i + n; }
+		
+		range_iterator& operator++() { ++_i; return *this; }
+		range_iterator& operator--() { --_i; return *this; }
+		range_iterator& operator+=(std::size_t n) { _i += n; return *this; }
+		range_iterator& operator-=(std::size_t n) { _i -= n; return *this; }
+
+		range_iterator operator++(int) { range_iterator copy(_i); ++_i; return copy; }
+		range_iterator operator--(int) { range_iterator copy(_i); --_i; return copy; }
+		
+		range_iterator operator+(std::size_t n) const { return range_iterator(_i + n); }
+		range_iterator operator-(std::size_t n) const { return range_iterator(_i - n); }
+		std::size_t operator-(const range_iterator& r) const { return _i - r._i; }
+	};
+	
+	// represents the i-th subrange of a range divides into n equal size range
+	class subrange {
+	public:
+		subrange(std::size_t first, std::size_t last, std::size_t i, std::size_t n)
+		{
+			assert(i < n);
+			assert(first <= last);
+			std::size_t dist = last-first;
+			std::size_t div = dist/n, rem = dist%n;
+			_begin = range_iterator(first + i*div + std::min(i,rem));
+			_end   = range_iterator(first + (i+1)*div + std::min(i+1,rem));
+		}
+		subrange(std::size_t size = 0, std::size_t i = 0, std::size_t n = 1)
+			: subrange(0, size, i ,n)
+		{
+		}
+		range_iterator begin() const { return _begin; }
+		range_iterator end() const { return _end; }
+		std::size_t first() const { return *_begin; }
+		std::size_t last() const { return *_end; }
+	private:
+		range_iterator _begin, _end;
+	};
+
+
+	// behaves as std::partition(first, last, Pred) in a parallel implementation using a given threadpool
+	template<typename RandIt, typename Pred, typename Threadpool>
+	RandIt partition(RandIt first, RandIt last, Pred pred, Threadpool& threadpool, const std::size_t chunksize = PA_PARTITION_CHUNKSIZE)
+	{
+		typedef typename std::iterator_traits<RandIt>::difference_type difference_type;
+		typedef typename std::iterator_traits<RandIt>::value_type value_type;
+
+		const std::size_t dist = last-first;
+
+		unsigned nr_threads = std::min(threadpool.size()+1, dist/(chunksize*2) );
+		if (nr_threads <= 2)
+			return std::partition(first, last, pred);
+
+		typedef std::pair<std::size_t,std::size_t> size_pair;
+		std::vector< size_pair > low_false_interval(nr_threads, size_pair(dist,dist));
+		std::vector< size_pair > high_true_interval(nr_threads, size_pair(dist,dist));
+
+		// we know there is enough room to give two chunks per thread (one at the begin, one at the end) at the start
+		// low and high point to the *beginning* of the next available chunk, so low<=high
+		std::atomic_size_t low(nr_threads*chunksize), high(dist - ((nr_threads+1)*chunksize));
+		std::atomic_size_t usedchunks(2*nr_threads);
+		const std::size_t availablechunks=dist/chunksize;
+
+		// each thread processes on a 'low' and a 'high' chunk, obtaining a new chunk whenever one is fully processed.
+		threadpool.run([&,first,last,dist,pred,chunksize,availablechunks](int thi, int thn)
+			{
+				assert(thn == nr_threads);
+				std::size_t mylow = thi*chunksize, myhigh = dist-(thi+1)*chunksize;
+				auto lowfirst=first+mylow, lowlast=lowfirst+chunksize, lowit=lowfirst;
+				auto highfirst=first+myhigh, highlast=highfirst+chunksize, highit=highfirst;
+				value_type tmp;
+
+				while (true)
+				{
+					for (; lowit != lowlast; ++lowit)
+					{
+						if (true == pred(*lowit))
+							continue;
+						for (; highit != highlast && false == pred(*highit); ++highit)
+							;
+						if (highit == highlast)
+							break;
+						std::iter_swap(lowit,highit);
+						++highit;
+					}
+					if (lowit == lowlast)
+					{
+						if (usedchunks.fetch_add(1) < availablechunks)
+						{
+							mylow = low.fetch_add(chunksize);
+							lowit = lowfirst = first+mylow; lowlast = lowfirst+chunksize;
+						} else
+							break;
+					}
+					if (highit == highlast)
+					{
+						if (usedchunks.fetch_add(1) < availablechunks)
+						{
+							myhigh = high.fetch_sub(chunksize);
+							highit = highfirst = first+myhigh; highlast = highfirst+chunksize;
+						} else
+							break;
+					}
+				}
+
+				if (lowit != lowlast)
+				{
+					auto lm = std::partition(lowit, lowlast, pred);
+					low_false_interval[thi] = size_pair(lm-first, lowlast-first);
+				} else
+					low_false_interval[thi] = size_pair(0,0);
+
+				if (highit != highlast)
+				{
+					auto hm = std::partition(highit, highlast, pred);
+					high_true_interval[thi] = size_pair(highit-first, hm-first);
+				} else
+					high_true_interval[thi] = size_pair(0,0);
+			}, nr_threads);
+
+		assert(low <= high+chunksize);
+
+		std::sort( low_false_interval.begin(), low_false_interval.end(), [](size_pair l,size_pair r){return l.first < r.first;});
+		std::sort( high_true_interval.begin(), high_true_interval.end(), [](size_pair l,size_pair r){return l.first < r.first;});
+
+		// current status:
+		// on range [0,mid)  : pred(*x)=true unless x in some low_todo_interval
+		// on range [mid,end): pred(*x)=false unless x in some high_todo_interval
+		std::size_t mid = std::partition(first+low, first+high+chunksize, pred) - first;
+
+		// compute the final middle
+		std::size_t realmid = mid;
+		for (auto& be : low_false_interval)
+			realmid -= be.second - be.first;
+		for (auto& be : high_true_interval)
+			realmid += be.second - be.first;
+
+		// compute the remaining intervals to swap
+		std::vector< size_pair > toswap_false, toswap_true;
+		std::sort( low_false_interval.begin(), low_false_interval.end() );
+		std::sort( high_true_interval.begin(), high_true_interval.end() );
+		
+		std::size_t lowdone = 0;
+		for (auto& be : low_false_interval)
+		{
+			assert(be.first <= be.second);
+			if (be.first == be.second)
+				continue;
+			// [lowdone, be.first): pred=true
+			// [be.first, be.second): pred=false
+			// case1: we have to swap [lowdone, be.first) intersect [realmid,be.first)
+			if (realmid < be.first && lowdone < be.first)
+				toswap_true.emplace_back(std::max(lowdone,realmid),be.first);
+			// case2: we have to swap [be.first, be.second) intersect [be.first, realmid)
+			if (be.first < realmid)
+				toswap_false.emplace_back(be.first,std::min(be.second,realmid));
+			lowdone = be.second;
+		}
+		// [lowdone,mid): pred=true
+		// case3: we have to swap [lowdone,mid) intersect [realmid,mid)
+		if (realmid < mid && lowdone < mid)
+			toswap_true.emplace_back(std::max(lowdone,realmid),mid);
+
+		std::size_t highdone = mid;
+		for (auto& be : high_true_interval)
+		{
+			assert(be.first <= be.second);
+			if (be.first == be.second)
+				continue;
+			// [highdone,be.first): pred=false
+			// [be.first, be.second): pred=true
+			// case4: we have to swap [highdone,be.first) intersect [highdone,realmid)
+			if (highdone < realmid && highdone < be.first)
+				toswap_false.emplace_back(highdone, std::min(be.first, realmid));
+			// case5: we have to swap [be.first, be.second) intersect [realmid, be.second)
+			if (realmid < be.second)
+				toswap_true.emplace_back(std::max(be.first,realmid), be.second);
+			highdone = be.second;
+		}
+		// [highdone,last): pred=false
+		if (highdone < realmid)
+			toswap_false.emplace_back(highdone, realmid);
+
+		// swap the remaining intervals
+		while (!toswap_false.empty() && !toswap_true.empty())
+		{
+			auto& swf = toswap_false.back();
+			auto& swt = toswap_true.back();
+			assert(swf.first <= swf.second);
+			assert(swt.first <= swt.second);
+			std::size_t count = std::min(swf.second-swf.first, swt.second-swt.first);
+			std::swap_ranges(first+swf.first, first+(swf.first+count), first+swt.first);
+			swf.first += count;
+			swt.first += count;
+			if (swf.first == swf.second)
+				toswap_false.pop_back();
+			if (swt.first == swt.second)
+				toswap_true.pop_back();
+		}
+		assert(toswap_false.empty() && toswap_true.empty());
+		return first+realmid;
+	}
+
+	// behaves as std::nth_element(first, nth, last, cf) in a parallel implementation using a given threadpool
+	template<typename RandIt, typename Compare, typename Threadpool>
+	void nth_element(RandIt first, RandIt nth, RandIt last, Compare cf, Threadpool& threadpool, std::size_t chunksize = PA_NTH_ELEMENT_CHUNKSIZE)
+	{
+		typedef typename std::iterator_traits<RandIt>::difference_type difference_type;
+		typedef typename std::iterator_traits<RandIt>::value_type value_type;
+		while (true)
+		{
+			assert(first <= nth && nth < last);
+			
+			difference_type dist = last - first;
+			if (dist <= chunksize*4)
+			{
+				std::nth_element(first, nth, last, cf);
+				return;
+			}
+
+			// select a small constant number of elements
+			const std::size_t selectionsize = 7;
+			assert(selectionsize <= dist);
+			RandIt selit = first;
+			for (std::size_t i = 0; i < selectionsize; ++i,++selit)
+				std::iter_swap(selit, first + (rand()%dist));
+			std::sort(first, selit, cf);
+			
+			// pick median as pivot and move to end
+			RandIt pivot = last-1;
+			std::iter_swap(first+selectionsize/2, pivot);
+			auto mid = partition(first, pivot, [cf,pivot](const value_type& r){ return cf(r, *pivot); }, threadpool, chunksize);
+			
+			if (nth < mid)
+				last = mid;
+			else
+				first = mid;
+		}
+	}
+
+	// behaves as std::nth_element(first, nth, last) in a parallel implementation using a given threadpool
+	template<typename RandIt, typename Threadpool>
+	void nth_element(RandIt first, RandIt nth, RandIt last, Threadpool& threadpool, std::size_t chunksize = PA_NTH_ELEMENT_CHUNKSIZE)
+	{
+		typedef typename std::iterator_traits<RandIt>::value_type value_type;
+		nth_element(first, nth, last, std::less<value_type>(), threadpool, chunksize);
+	}
+
+
+	// behaves as std::merge(first1, last1, first2, last2, dest, cf) in a parallel implementation using a given threadpool
+	template<typename RandIt1, typename RandIt2, typename OutputIt, typename Compare, typename Threadpool>
+	OutputIt merge(RandIt1 first1, RandIt1 last1, RandIt2 first2, RandIt2 last2, OutputIt dest, Compare cf, Threadpool& threadpool)
+	{
+		typedef typename std::iterator_traits<OutputIt>::difference_type difference_type;
+		const std::size_t minchunksize = 4096;
+
+		difference_type size1 = last1-first1, size2=last2-first2;
+		if (size1+size2 < 2*minchunksize)
+			return std::merge(first1, last1, first2, last2, dest, cf);
+		if (size1 < size2)
+			return merge(first2, last2, first1, last1, dest, cf, threadpool);
+
+		const std::size_t threads = std::min(threadpool.size()+1, size1/minchunksize);
+
+		threadpool.run([=](int thi, int thn)
+			{
+				subrange iv1(size1, thi, thn);
+				RandIt1 iv1first=first1 + iv1.first(), iv1last=first1 + iv1.last();
+				RandIt2 iv2first=first2, iv2last=last2;
+				if (thi>0)
+					iv2first=std::lower_bound(first2, last2, *iv1first, cf);
+				OutputIt d = dest + (iv1.first() + (iv2first-first2));
+				if (iv2first == iv2last)
+				{
+					std::move(iv1first, iv1last, d);
+					return;
+				}
+				while (true)
+				{
+					if (cf(*iv1first,*iv2first))
+					{
+						*d = std::move(*iv1first); ++d;
+						if (++iv1first == iv1last)
+						{
+							if (thi<thn-1)
+							{
+								for (; iv2first != iv2last && cf(*iv2first, *iv1last); ++iv2first,++d)
+									*d = std::move(*iv2first);
+							} else
+								std::move(iv2first, iv2last, d);
+							return;
+						}
+					} else
+					{
+						*d = std::move(*iv2first); ++d;
+						if (++iv2first == iv2last)
+						{
+							std::move(iv1first, iv1last, d);
+							return;
+						}
+					}
+				}
+			});
+		return dest+(size1+size2);
+	}
+
+	// behaves as std::merge(first1, last1, first2, last2, dest) in a parallel implementation using a given threadpool
+	template<typename RandIt1, typename RandIt2, typename OutputIt, typename Threadpool>
+	OutputIt merge(RandIt1 first1, RandIt1 last1, RandIt2 first2, RandIt2 last2, OutputIt dest, Threadpool& threadpool)
+	{
+		typedef typename std::iterator_traits<OutputIt>::value_type value_type;
+		return merge(first1, last1, first2, last2, dest, std::less<value_type>(), threadpool);
+	}
+
+
+	// behaves as std::sort(first, last, cf) in a parallel implementation using a given threadpool
+	template<typename RandIt, typename Compare, typename Threadpool>
+	void sort2(RandIt first, RandIt last, Compare cf, Threadpool& threadpool, const std::size_t chunksize = PA_SORT_CHUNKSIZE)
+	{
+		typedef typename std::iterator_traits<RandIt>::value_type value_type;
+		typedef thread_pool::barrier barrier;
+
+		const std::size_t dist = last-first;
+		std::size_t nr_threads = std::min(threadpool.size()+1, dist/chunksize);
+		if (nr_threads <= 1)
+		{
+			std::sort(first, last, cf);
+			return;
+		}
+
+		typedef std::pair<std::size_t,std::size_t> size_pair;
+		std::vector<subrange> thrange(nr_threads);
+		for (size_t i = 0; i < nr_threads; ++i)
+			thrange[i] = subrange(dist, i, nr_threads);
+
+		int windowsize = 1;
+		while (windowsize < nr_threads)
+			windowsize *= 2;
+
+		while (windowsize > 1
+			&& (((dist/nr_threads)*windowsize)/(3*chunksize)) > (nr_threads/windowsize))
+		{
+			for (int th = 0; th < nr_threads; th += windowsize)
+			{
+				int fth = th;
+				int mth = std::min<int>(nr_threads-1, th+windowsize/2);
+				int lth = std::min<int>(nr_threads-1, th+windowsize-1);
+				nth_element(first + thrange[th].first(), first + thrange[mth].first(), first + thrange[lth].last(), cf, threadpool, chunksize);
+			}
+			windowsize /= 2;
+		}
+
+		barrier barriers(nr_threads);
+		threadpool.run(
+			[=,&barriers,&thrange](int thi, int thn)
+			{
+				for (int w = windowsize; w > 1; w /= 2)
+				{
+					if ((thi % w) == 0)
+					{
+						int fth = thi;
+						int mth = std::min<int>(thn-1, thi+w/2);
+						int lth = std::min<int>(thn-1, thi+w-1);
+						std::nth_element(first + thrange[fth].first(), first + thrange[mth].first(), first+thrange[lth].last(), cf);
+					}
+					barriers.wait();
+				}
+				std::sort(first+thrange[thi].first(), first+thrange[thi].last(), cf);
+			}, nr_threads);
+	}
+
+	// behaves as std::sort(first, last) in a parallel implementation using a given threadpool
+	template<typename RandIt, typename Threadpool>
+	void sort2(RandIt first, RandIt last, Threadpool& threadpool, const std::size_t chunksize = PA_SORT_CHUNKSIZE)
+	{
+		typedef typename std::iterator_traits<RandIt>::value_type value_type;
+		sort2(first, last, std::less<value_type>(), threadpool, chunksize);
+	}
+
+	// behaves as std::sort(first, last, cf) in a parallel implementation using a given threadpool
+	template<typename RandIt, typename Compare, typename Threadpool>
+	void sort3(RandIt first, RandIt last, Compare cf, Threadpool& threadpool, const std::size_t chunksize = PA_SORT_CHUNKSIZE)
+	{
+		typedef typename std::iterator_traits<RandIt>::value_type value_type;
+		typedef thread_pool::barrier barrier;
+
+		const std::size_t dist = last-first;
+		std::size_t nr_threads = std::min(threadpool.size()+1, dist/chunksize);
+		if (nr_threads <= 2)
+		{
+			std::sort(first, last, cf);
+			return;
+		}
+
+		typedef std::pair<std::size_t,std::size_t> size_pair;
+		std::vector<size_pair> ranges;
+
+		ranges.emplace_back(0, dist);
+
+		while (ranges.size() < nr_threads)
+		{
+			size_pair largest = ranges.back();
+
+			RandIt rf = first + largest.first;
+			RandIt rl = rf + largest.second;
+
+			// select a small constant number of elements
+			const std::size_t selectionsize = 7;
+			RandIt selit = rf;
+			for (std::size_t i = 0; i < selectionsize; ++i,++selit)
+				std::iter_swap(selit, rf + (rand() % largest.second));
+			std::sort(rf, selit, cf);
+
+			// pick median as pivot and move to end
+			RandIt pivot = rl-1;
+			std::iter_swap(rf + selectionsize/2, pivot);
+			auto mid = partition(rf, pivot, [cf,pivot](const value_type& r){ return cf(r, *pivot); }, threadpool, chunksize);
+
+			// update ranges
+			ranges.pop_back();
+			size_pair subrange1(largest.first, mid-rf);
+			size_pair subrange2(subrange1.first+subrange1.second, largest.second-subrange1.second);
+			ranges.insert(
+				std::upper_bound(ranges.begin(),ranges.end(),subrange1,[](const size_pair& l, const size_pair& r){return l.second < r.second;})
+				, subrange1);
+			ranges.insert(
+				std::upper_bound(ranges.begin(),ranges.end(),subrange2,[](const size_pair& l, const size_pair& r){return l.second < r.second;})
+				, subrange2);
+		}
+
+		threadpool.run(
+			[=](int thi, int thn)
+			{
+				std::sort(first + ranges[thi].first, first + (ranges[thi].first+ranges[thi].second), cf);
+/* // attempt to more evenly divide the sorting space
+				if (ranges.size() == 2*nr_threads)
+					std::sort(first + ranges[2*thn-thi-1].first, first + (ranges[2*thn-thi-1].first+ranges[2*thn-thi-1].second), cf);
+*/
+			}
+			, nr_threads);
+	}
+
+	// behaves as std::sort(first, last) in a parallel implementation using a given threadpool
+	template<typename RandIt, typename Threadpool>
+	void sort3(RandIt first, RandIt last, Threadpool& threadpool, const std::size_t chunksize = PA_SORT_CHUNKSIZE)
+	{
+		typedef typename std::iterator_traits<RandIt>::value_type value_type;
+		sort3(first, last, std::less<value_type>(), threadpool, chunksize);
+	}
+
+	// behaves as std::sort(first, last, cf) in a parallel implementation using a given threadpool
+	template<typename RandIt, typename Compare, typename Threadpool>
+	void sort(RandIt first, RandIt last, Compare cf, Threadpool& threadpool, const std::size_t chunksize = PA_SORT_CHUNKSIZE)
+	{
+		sort3(first, last, cf, threadpool, chunksize);
+	}
+
+	// behaves as std::sort(first, last) in a parallel implementation using a given threadpool
+	template<typename RandIt, typename Threadpool>
+	void sort(RandIt first, RandIt last, Threadpool& threadpool, const std::size_t chunksize = PA_SORT_CHUNKSIZE)
+	{
+		typedef typename std::iterator_traits<RandIt>::value_type value_type;
+		sort3(first, last, std::less<value_type>(), threadpool, chunksize);
+	}
+
+} // namespace parallel_algorithms
+
+#endif // PARALLEL_ALGORITHMS

--- a/kernel/parallel_algorithms.hpp
+++ b/kernel/parallel_algorithms.hpp
@@ -208,7 +208,8 @@ namespace parallel_algorithms {
 		// each thread processes on a 'low' and a 'high' chunk, obtaining a new chunk whenever one is fully processed.
 		threadpool.run([&,first,last,dist,pred,chunksize,availablechunks](int thi, int thn)
 			{
-				assert(thn == nr_threads);
+				if (thn != nr_threads)
+					throw std::runtime_error("thn != nr_threads");
 				std::size_t mylow = thi*chunksize, myhigh = dist-(thi+1)*chunksize;
 				auto lowfirst=first+mylow, lowlast=lowfirst+chunksize, lowit=lowfirst;
 				auto highfirst=first+myhigh, highlast=highfirst+chunksize, highit=highfirst;
@@ -398,7 +399,7 @@ namespace parallel_algorithms {
 		const std::size_t minchunksize = 4096;
 
 		difference_type size1 = last1-first1, size2=last2-first2;
-		if (size1+size2 < 2*minchunksize)
+		if (size1+size2 < difference_type(2*minchunksize))
 			return std::merge(first1, last1, first2, last2, dest, cf);
 		if (size1 < size2)
 			return merge(first2, last2, first1, last1, dest, cf, threadpool);

--- a/kernel/siever.h
+++ b/kernel/siever.h
@@ -289,7 +289,10 @@ struct CompressedEntry {
 };
 
 // Define an ordering for sorting Compressed Entries, used for sorting.
-inline bool compare_CE(CompressedEntry const& lhs, CompressedEntry const& rhs) { return lhs.len < rhs.len; }
+struct compare_CE
+{
+    bool operator()(const CompressedEntry& lhs, const CompressedEntry& rhs) const { return lhs.len < rhs.len; }
+};
 
 /**
     An elements in the filtered_list (only used in single-threaded triple sieve)
@@ -463,9 +466,8 @@ public:
     // TODO: Document parameter large
     void grow_db(unsigned long N, unsigned int large = 0); // implemented in control.cpp
 
-    void shrink_db_task(size_t const start, size_t const end, std::vector<IT>& to_save, std::vector<IT>& to_kill);
      // Sorts and shrink the database, keeping only the N best vectors
-    void shrink_db(unsigned long N); // implemented in control.cpp
+    void shrink_db(unsigned long N, bool erase_uid = true); // implemented in control.cpp
 
     // Debug-only function. This makes a self-check of various invariants.
     // Should always return true. Will print (at least) the first problem that was found to std::cerr.

--- a/kernel/siever.h
+++ b/kernel/siever.h
@@ -604,7 +604,7 @@ private:
 
     bool histo_valid = false;
 
-    CACHELINE_VARIABLE(std::vector<CompressedEntry>, bgj1_cdb_copy);   // temporary copy for sorting without affecting other threads
+    CACHELINE_VARIABLE(std::vector<CompressedEntry>, cdb_tmp_copy);   // temporary copy for sorting without affecting other threads
 
     CACHELINE_VARIABLE(std::vector<LiftEntry>, best_lifts_so_far); // vector of size r, containing good (i.e. short) vectors lifts so far.
                                           // More precisely, best_lifts_so_far[i] is an "Entry" of size r, whose GSO-projection onto
@@ -654,7 +654,7 @@ private:
     // consider renaming
     void set_lift_bounds(); // in control.cpp
 
-    // pre-allocate db_size slots for db and cdb (and bgj1_cdb_copy ???)
+    // pre-allocate db_size slots for db and cdb (and cdb_tmp_copy ???)
     void reserve(size_t reserve_db_size); // in control.cpp
 
     // Sets the number of threads used. Note that the threadpool uses nr-1 threads. It is intended
@@ -1056,7 +1056,7 @@ private:
     long GBL_max_trial; // maximum number of buckets bgj1 will consider between resorting before it gives up.
     CACHELINE_VARIABLE(std::atomic<std::int64_t>, GBL_remaining_trial);
     CACHELINE_VARIABLE(std::mutex, GBL_db_mutex);
-    CACHELINE_VARIABLE(std::atomic<CompressedEntry*>, GBL_start_of_cdb_ptr); // point always either to the start of cdb or to bgj1_cdb_copy (due to for sorting)
+    CACHELINE_VARIABLE(std::atomic<CompressedEntry*>, GBL_start_of_cdb_ptr); // point always either to the start of cdb or to cdb_tmp_copy (due to for sorting)
 
     // saturation stop conditions
     double GBL_saturation_histo_bound[Siever::size_of_histo]; // used by gauss sieve & triple sieve

--- a/kernel/sieving.cpp
+++ b/kernel/sieving.cpp
@@ -63,7 +63,7 @@ void Siever::gauss_sieve(size_t max_db_size)
         // sort the old and new part separately. Note that (except at the beginning), these also
         // correspond to the distinction explained above. The old part already is sorted: We sort
         // the 'queue'-part; shorter vectors to be processed first
-        std::sort(cdb.begin() + old_S, cdb.end(),  &compare_CE);
+        pa::sort(cdb.begin() + old_S, cdb.end(), compare_CE(), threadpool);
         //CompressedEntry* const fast_cdb = &(cdb.front());
         CompressedEntry* const fast_cdb = cdb.data();
         // while there is no elements in the 'queue'-part of the list
@@ -159,7 +159,7 @@ bool Siever::nv_sieve()
             if (kk < .5 * S) break;
         }
 
-        std::sort(cdb.begin(), cdb.end(), &compare_CE);
+        pa::sort(cdb.begin(), cdb.end(), compare_CE(), threadpool);
         status_data.plain_data.sorted_until = cdb.size();
 
         if (kk > .8 *S) return false;
@@ -172,7 +172,7 @@ bool Siever::nv_sieve()
             cumul += histo[i];
             if (i>=imin && 1.99 * cumul > std::pow(1. + i* (1./size_of_histo), n/2.) * params.saturation_ratio)
             {
-                assert(std::is_sorted(cdb.cbegin(),cdb.cend(), &compare_CE  ));
+                assert(std::is_sorted(cdb.cbegin(),cdb.cend(), compare_CE()  ));
                 return true;
             }
         }

--- a/kernel/thread_pool.hpp
+++ b/kernel/thread_pool.hpp
@@ -105,6 +105,9 @@ namespace thread_pool {
 		// stop the thread pool
 		void stop();
 
+		// process single task
+		bool work();
+
 		// process tasks & then wait until all threads are idle
 		void wait_work();
 
@@ -166,20 +169,24 @@ namespace thread_pool {
 		resize(0);
 	}
 
-	inline void thread_pool::wait_work()
+	inline bool thread_pool::work()
 	{
 		std::function<void()> task;
-		std::unique_lock<std::mutex> lock(_mutex);
-		while (!_tasks.empty())
 		{
+			std::lock_guard<std::mutex> lock(_mutex);
+			if (_tasks.empty())
+				return false;
 			task = std::move(this->_tasks.front());
 			this->_tasks.pop();
-
-			lock.unlock();
-			task();
-			lock.lock();
 		}
-		lock.unlock();
+		task();
+		return true;
+	}
+
+	inline void thread_pool::wait_work()
+	{
+		while (work())
+			;
 		while (_threads_busy != 0)
 			std::this_thread::yield();
 	}
@@ -192,15 +199,19 @@ namespace thread_pool {
 
 	inline void thread_pool::push(const std::function<void()>& f)
 	{
-		std::unique_lock<std::mutex> lock(_mutex);
-		_tasks.emplace(f);
+		{
+			std::unique_lock<std::mutex> lock(_mutex);
+			_tasks.emplace(f);
+		}
 		_condition.notify_one();
 	}
 
 	inline void thread_pool::push(std::function<void()>&& f)
 	{
-		std::unique_lock<std::mutex> lock(_mutex);
-		_tasks.emplace(std::move(f));
+		{
+			std::unique_lock<std::mutex> lock(_mutex);
+			_tasks.emplace(std::move(f));
+		}
 		_condition.notify_one();
 	}
 
@@ -217,29 +228,44 @@ namespace thread_pool {
 
 	inline void thread_pool::run(const std::function<void()>& f, int threads)
 	{
-		if (threads == -1 || threads > int(_threads.size()+1))
-			threads = _threads.size()+1;
-		for (int i = 0; i < threads; ++i)
-			this->push(f);
-		this->wait_work();
+		if (threads < 1 || threads > int(_threads.size())+1)
+			threads = int(_threads.size())+1;
+		{
+			std::unique_lock<std::mutex> lock(_mutex);
+			for (int i = 0; i < threads-1; ++i)
+				_tasks.emplace(f);
+		}
+		_condition.notify_all();
+		f();
+		this->wait_sleep();
 	}
 
 	inline void thread_pool::run(const std::function<void(int)>& f, int threads)
 	{
-		if (threads == -1 || threads > int(_threads.size()+1))
-			threads = _threads.size()+1;
-		for (int i = 0; i < threads; ++i)
-			this->push( [f,i](){f(i);} );
-		this->wait_work();
+		if (threads < 1 || threads > int(_threads.size())+1)
+			threads = int(_threads.size())+1;
+		{
+			std::unique_lock<std::mutex> lock(_mutex);
+			for (int i = 0; i < threads-1; ++i)
+				_tasks.emplace( [=](){f(i);} );
+		}
+		_condition.notify_all();
+		f(threads-1);
+		this->wait_sleep();
 	}
 
 	inline void thread_pool::run(const std::function<void(int,int)>& f, int threads)
 	{
-		if (threads == -1 || threads > int(_threads.size()+1))
-			threads = _threads.size()+1;
-		for (int i = 0; i < threads; ++i)
-			this->push( [f,i,threads](){f(i,threads);} );
-		this->wait_work();
+		if (threads < 1 || threads > int(_threads.size())+1)
+			threads = int(_threads.size())+1;
+		{
+			std::unique_lock<std::mutex> lock(_mutex);
+			for (int i = 0; i < threads-1; ++i)
+				_tasks.emplace( [=](){f(i,threads);} );
+		}
+		_condition.notify_all();
+		f(threads-1,threads);
+		this->wait_sleep();
 	}
 
 	inline void thread_pool::resize(std::size_t nrthreads)
@@ -247,13 +273,15 @@ namespace thread_pool {
 		if (nrthreads < _threads.size())
 		{
 			// decreasing number of active threads
+			std::unique_lock<std::mutex> lock(_mutex);
 			for (std::size_t i = nrthreads; i < _threads.size(); ++i)
 				*(_threads_stop[i]) = true;
 			_condition.notify_all();
+			lock.unlock();
 			for (std::size_t i = nrthreads; i < _threads.size(); ++i)
 				_threads[i]->join();
 
-			std::unique_lock<std::mutex> lock(_mutex);
+			lock.lock();
 			_threads_stop.resize(nrthreads);
 			_threads.resize(nrthreads);
 		} 
@@ -323,6 +351,7 @@ namespace thread_pool {
 		if (++_i >= _count)
 		{
 			_i = 0;
+			lock.unlock();
 			_condition.notify_all();
 		}
 		else

--- a/kernel/triple_sieve.cpp
+++ b/kernel/triple_sieve.cpp
@@ -209,7 +209,7 @@ void Siever::gauss_triple_sieve_st(size_t max_db_size)
         size_t const old_S = status_data.gauss_data.queue_start;
         if (iter) grow_db(cdb.size()*1.02 + 10);
         ++iter;
-        std::sort(cdb.begin() + old_S, cdb.end(), &compare_CE);
+        pa::sort(cdb.begin() + old_S, cdb.end(), compare_CE(), threadpool);
 
         CompressedEntry* const fast_cdb = cdb.data();
 
@@ -360,7 +360,7 @@ start_over:
 
         } // while (queue_begin < cdb.size())
 
-        std::sort(cdb.begin(), cdb.end(), &compare_CE);
+        pa::sort(cdb.begin(), cdb.end(), compare_CE(), threadpool);
         status_data.gauss_data.list_sorted_until = cdb.size();
         status_data.gauss_data.queue_start = cdb.size();
         status_data.gauss_data.queue_sorted_until = cdb.size();

--- a/kernel/triple_sieve_mt.cpp
+++ b/kernel/triple_sieve_mt.cpp
@@ -447,8 +447,8 @@ void Siever::gauss_triple_mt(double alpha)
     status_data.gauss_data.queue_start = TS_start_queue_original;
     status_data.gauss_data.list_sorted_until = TS_start_queue_original;
     status_data.gauss_data.queue_sorted_until = cdb.size();
-    assert(std::is_sorted(cdb.cbegin(), cdb.cbegin() + TS_start_queue_original, &compare_CE ));
-    assert(std::is_sorted(cdb.cbegin() + TS_start_queue_original, cdb.cend(), &compare_CE));
+    assert(std::is_sorted(cdb.cbegin(), cdb.cbegin() + TS_start_queue_original, compare_CE() ));
+    assert(std::is_sorted(cdb.cbegin() + TS_start_queue_original, cdb.cend(), compare_CE() ));
     recompute_histo();
 
 ENABLE_IF_STATS_MEMORY
@@ -960,14 +960,14 @@ void Siever::gauss_triple_mt_resort(MAYBE_UNUSED unsigned int const id)
     assert(start_new_cdb_overwritten_queue >= start_new_cdb_overwritten_list);
     assert(start_old_cdb_processed_queue - start_old_cdb_overwritten_list == start_new_cdb_overwritten_queue - start_new_cdb_overwritten_list);
     std::partial_sort_copy( start_old_cdb_overwritten_list, start_old_cdb_processed_queue,
-                            start_new_cdb_overwritten_list, start_new_cdb_overwritten_queue, compare_CE);
+                            start_new_cdb_overwritten_list, start_new_cdb_overwritten_queue, compare_CE());
 
     // copy & sort V
     assert(end_old_cdb >= start_old_cdb_overwritten_queue);
     assert(end_new_cdb >= start_new_cdb_overwritten_queue);
     assert(end_old_cdb - start_old_cdb_overwritten_queue == end_new_cdb - start_new_cdb_overwritten_queue);
     std::partial_sort_copy(start_old_cdb_overwritten_queue, end_old_cdb,
-                           start_new_cdb_overwritten_queue, end_new_cdb, compare_CE);
+                           start_new_cdb_overwritten_queue, end_new_cdb, compare_CE());
 
     // We now have reordered I-II-III-IV-V into I-III-IV-II-V and sorted each indidivual piece.
     // Furthermore (III-IV) is still sorted as a whole
@@ -975,7 +975,7 @@ void Siever::gauss_triple_mt_resort(MAYBE_UNUSED unsigned int const id)
     // Merge-sort II and V
     assert(start_new_cdb_overwritten_list <= start_new_cdb_overwritten_queue);
     assert(start_new_cdb_overwritten_queue <= end_new_cdb);
-    std::inplace_merge(start_new_cdb_overwritten_list, start_new_cdb_overwritten_queue, end_new_cdb, compare_CE);
+    std::inplace_merge(start_new_cdb_overwritten_list, start_new_cdb_overwritten_queue, end_new_cdb, compare_CE());
 
     // separate III from IV, this requires another lock
     { // scope for lock_guard
@@ -999,10 +999,10 @@ void Siever::gauss_triple_mt_resort(MAYBE_UNUSED unsigned int const id)
 
         assert(start_new_cdb_untouched_list <= start_new_cdb_processed_queue);
         assert(start_new_cdb_processed_queue <= start_new_cdb_unprocessed_queue);
-        std::inplace_merge(start_new_cdb_untouched_list, start_new_cdb_processed_queue, start_new_cdb_unprocessed_queue, compare_CE);
+        std::inplace_merge(start_new_cdb_untouched_list, start_new_cdb_processed_queue, start_new_cdb_unprocessed_queue, compare_CE());
         assert(start_new_cdb_unprocessed_queue <= start_new_cdb_overwritten_list);
         assert(start_new_cdb_overwritten_list <= end_new_cdb);
-        std::inplace_merge(start_new_cdb_unprocessed_queue, start_new_cdb_overwritten_list, end_new_cdb, compare_CE);
+        std::inplace_merge(start_new_cdb_unprocessed_queue, start_new_cdb_overwritten_list, end_new_cdb, compare_CE());
 
         // finished creating the data of the new snapshot. We now set up the metadata:
         assert(new_list_size <= db_size);


### PR DESCRIPTION
I have added `kernel/parallel_algorithms.hpp` from https://github.com/cr-marcstevens/snippets, and this is used in several places to simplify and improve multithreaded operations.
Notably:
- shrink_db (also fixing a bug: not all uid that needed to be erased were erased)
- parallel_sort_cdb
- sorting within `sieving.cpp` & `triple_sieve.cpp`

Other improvement:
- function compare_CE is now a struct:
  passing as a function pointer to `sort` etc doesn't allow function inlining,
  while passing as a struct does.

This reduces 'overhead walltime' by almost a factor 1.8 for larger dims, e.g.:
`python ./full_sieve.py 110 --saturation-ratio 0 --threads 80`
`before:  cputime 6631.2597s, walltime: 325.0279s`
`after : cputime 6764.1946s, walltime: 182.2982s`
