### PR TITLE
Exit on failure in bootstrap.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,6 +37,9 @@ Otherwise, you will need fplll and fpylll already installed and build the G6K Cy
 
 Remove ``-f`` option to compile faster (fewer optimisations). See ``rebuild.sh`` for more options.
 
+If building via ```./bootstrap.sh``` fails, then the script will return an error code. 
+The error codes are documented in ```bootstrap.sh.```
+
 
 Tests
 =====

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -75,9 +75,9 @@ git clone https://github.com/fplll/fplll g6k-fplll
 cd g6k-fplll || exit
 ./autogen.sh
 ./configure --prefix="$VIRTUAL_ENV" $CONFIGURE_FLAGS
-make clean
-make $jobs
-make install
+make clean || exit
+make $jobs || exit
+make install || exit
 cd ..
 
 # Install FPyLLL
@@ -86,13 +86,13 @@ cd g6k-fpylll || exit
 $PIP install Cython
 $PIP install -r requirements.txt
 $PIP install -r suggestions.txt
-$PYTHON setup.py clean
+$PYTHON setup.py clean || exit
 $PYTHON setup.py build_ext $jobs || $PYTHON setup.py build_ext
-$PYTHON setup.py install
+$PYTHON setup.py install || exit
 cd ..
 
 $PIP install -r requirements.txt
-$PYTHON setup.py clean
+$PYTHON setup.py clean || exit
 $PYTHON setup.py build_ext $jobs --inplace || $PYTHON setup.py build_ext --inplace
 
 echo " "

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -75,9 +75,31 @@ git clone https://github.com/fplll/fplll g6k-fplll
 cd g6k-fplll || exit
 ./autogen.sh
 ./configure --prefix="$VIRTUAL_ENV" $CONFIGURE_FLAGS
-make clean #|| exit
-make $jobs #|| exit
-make install #|| exit
+make clean
+retval=$?
+if [ $retval -ne 0 ]; then
+    echo "Make clean failed in fplll. This is usually because there was an error with either autogen.sh or configure."
+    echo "Check the logs above - they'll contain more information."
+    exit 1 # 1 is the exit value if building fplll fails via configure or autogen
+fi
+
+make $jobs
+retval=$?
+if [$retval -ne 0 ]; then
+    echo "Making fplll failed."
+    echo "Check the logs above - they'll contain more information."
+    exit 2 # 2 is the exit value if building fplll fails as a result of make $jobs.
+fi
+
+make install
+retval=$?
+
+if [$retval -ne 0 ]; then
+    echo "Make install failed for fplll."
+    echo "Check the logs above - they'll contain more information."
+    exit 3 # 3 is the exit value if installing fplll failed.
+fi
+
 cd ..
 
 # Install FPyLLL

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -75,9 +75,9 @@ git clone https://github.com/fplll/fplll g6k-fplll
 cd g6k-fplll || exit
 ./autogen.sh
 ./configure --prefix="$VIRTUAL_ENV" $CONFIGURE_FLAGS
-make clean || exit
-make $jobs || exit
-make install || exit
+make clean #|| exit
+make $jobs #|| exit
+make install #|| exit
 cd ..
 
 # Install FPyLLL
@@ -86,13 +86,13 @@ cd g6k-fpylll || exit
 $PIP install Cython
 $PIP install -r requirements.txt
 $PIP install -r suggestions.txt
-$PYTHON setup.py clean || exit
+$PYTHON setup.py clean
 $PYTHON setup.py build_ext $jobs || $PYTHON setup.py build_ext
-$PYTHON setup.py install || exit
+$PYTHON setup.py install
 cd ..
 
 $PIP install -r requirements.txt
-$PYTHON setup.py clean || exit
+$PYTHON setup.py clean
 $PYTHON setup.py build_ext $jobs --inplace || $PYTHON setup.py build_ext --inplace
 
 echo " "


### PR DESCRIPTION
The current version of G6K's bootstrap will assume that making fplll and fpylll are successful before proceeding on to building G6K.

Usually this is OK, but it can cover up some bugs that are hard to find (visually, at least).

For example, today I installed G6K on a box with a very outdated version of GMP - but, although make (rightfully) warns about this, the script continues. You can see this below:

```
configure: error: GMP version >= 4.2.0 needed, see http://gmplib.org
make: *** No rule to make target `clean'.  Stop.
make: *** No targets specified and no makefile found.  Stop.
make: Nothing to be done for `install'.
Cloning into 'g6k-fpylll'...
```

Here, you can see that the script continues regardless, even though fplll hasn't been built properly. This eventually leads to the build script crashing, but it's probably better for it to fail early. 

This pull request just adds ``|| exit `` to appropriate calls to make, so that it exits early if the build process fails.  