### PR TITLE
Parallel

### DIFF
--- a/kernel/compat.hpp
+++ b/kernel/compat.hpp
@@ -410,7 +410,7 @@ inline constexpr ENUMNAME operator~(ENUMNAME const arg) \
 // MACRO for cachline padding: ensure this variable is in its own cacheline
 // this prevents unnecessary cacheline contention between CPUs
 // because several unrelated global variables are in the same cacheline
-struct cacheline_padding_t { uint64_t pad[8]; };
+struct cacheline_padding_t { uint64_t pad[16]; };
 // _ ## NOTE: added to interfere less with auto-completion of my editor
 #define CACHELINE_VARIABLE(type,name) cacheline_padding_t _ ## name ## prepad; type name; cacheline_padding_t _ ## name ## postpad;
 #define CACHELINE_VARIABLE2(type,name,init) cacheline_padding_t _ ## name ## prepad; type name init; cacheline_padding_t _ ## name ## postpad;

--- a/kernel/hash_table.inl
+++ b/kernel/hash_table.inl
@@ -13,8 +13,11 @@ inline void UidHashTable::reset_hash_function(Siever& siever)
     uid_coeffs.resize(n);
     for (unsigned i = 0; i < n; i++)
         uid_coeffs[i] = siever.rng.rng_nolock();
-    for (unsigned i = 0; i < DB_UID_SPLIT; ++i)
-        db_uid[i].clear();
+    siever.threadpool.run([this](int th_i, int th_n)
+    {
+        for (auto j : pa::subrange(DB_UID_SPLIT, th_i, th_n))
+            db_uid[j].clear();
+    });
     insert_uid(0);
     return;
 }

--- a/kernel/siever.h
+++ b/kernel/siever.h
@@ -194,7 +194,8 @@ private:
     }
 
     // Note: The splitting is purely to allow better parallelism.
-    std::array<std::unordered_set<UidType>, DB_UID_SPLIT> db_uid;     // Sets of the uids of all vectors of the database. db_uid[i] contains only vectors with (normalized) uid % DB_UID_SPLIT == i.
+    struct padded_map: std::unordered_set<UidType> { cacheline_padding_t pad; };
+    std::array<padded_map, DB_UID_SPLIT> db_uid;     // Sets of the uids of all vectors of the database. db_uid[i] contains only vectors with (normalized) uid % DB_UID_SPLIT == i.
     struct padded_mutex: std::mutex { cacheline_padding_t pad; };
     std::array<padded_mutex, DB_UID_SPLIT> db_mut; // array of mutexes. db_mut[i] protects all access to db_uid[i].    unsigned int n; // dimension of points in the domain of the hash function.
     unsigned int n; // dimension of points in the domain of the hash function.

--- a/kernel/siever.h
+++ b/kernel/siever.h
@@ -195,7 +195,8 @@ private:
 
     // Note: The splitting is purely to allow better parallelism.
     std::array<std::unordered_set<UidType>, DB_UID_SPLIT> db_uid;     // Sets of the uids of all vectors of the database. db_uid[i] contains only vectors with (normalized) uid % DB_UID_SPLIT == i.
-    std::array<std::mutex, DB_UID_SPLIT> db_mut; // array of mutexes. db_mut[i] protects all access to db_uid[i].
+    struct padded_mutex: std::mutex { cacheline_padding_t pad; };
+    std::array<padded_mutex, DB_UID_SPLIT> db_mut; // array of mutexes. db_mut[i] protects all access to db_uid[i].    unsigned int n; // dimension of points in the domain of the hash function.
     unsigned int n; // dimension of points in the domain of the hash function.
                     // The hash function only works on vectors of this size
     std::vector<UidType> uid_coeffs;        // description of the hash function.


### PR DESCRIPTION
Now parallelize uid_reset as well, with better cacheline alignments.

For the Record, the recent efforts (on this branch mostly) have lead to significant improvements:
compared to commit 7480e0a82becfc5aa3913dab96a1463126112967,

Average wall time:
` ./full_sieve.py $n --sieve gauss_triple_mt --threads 40 --trials 5`
(the machine has 20 physical core, so hyperthreading is on)

```
n		BEFORE		AFTER		SPEED-UP
50		0.2801		0.2344		1.19
52		0.3226		0.258		1.25
54		0.3531		0.2908		1.21
56		0.4975		0.4024		1.23
58		0.5732		0.4626		1.23
60		0.7243		0.5315		1.36
62		0.8949		0.6631		1.34
64		1.0563		0.7853		1.34
66		1.2951		0.9386		1.37
68		1.626		1.1888		1.36
70		2.1749		1.4949		1.45
72		2.7428		1.9292		1.42
74		3.6541		2.5992		1.40
76		4.8213		3.7525		1.28
78		6.6314		5.2916		1.25
80		9.3912		7.3172		1.28
82		13.9432		11.128		1.25
84		20.9074		17.552		1.19
86		31.0207		25.4121		1.22
```