### PR TITLE
Fixed documentation regarding using enum in svp_exact.py

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -97,7 +97,7 @@ Which will take around 10 seconds. To compare several algorithms, and average ov
 
 .. code-block:: bash
 
-    python ./svp_exact.py 50 --workers 3 --trials 5 --challenge-seed 0 1 2 --sieve gauss bgj1 enum
+    python ./svp_exact.py 50 --workers 3 --trials 5 --challenge-seed 0 1 2 --svp/alg workout enum
 
 
 SVP-challenge (Sec 6.2)

--- a/g6k/siever.pyx
+++ b/g6k/siever.pyx
@@ -1248,6 +1248,18 @@ cdef class Siever(object):
 
     def __call__(self, alg=None, reset_stats=True, tracer=dummy_tracer):
         assert(self.initialized)
+
+        # Check choice of sieve algorithm preemptively, to avoid incorrect user 
+        # choices  being overwritten by default or crossover leading to non-deterministic 
+        # raise of the error
+
+        valid_sieves = ["nv", "bgj1", "gauss", "gauss_triple_st", "gauss_triple_mt"]
+        if alg is not None and alg not in valid_sieves:
+            raise NotImplementedError("Sieve Algorithm '%s' invalid. "%(alg) + "Please choose among "+str(valid_sieves) )
+
+        if self.params.default_sieve not in valid_sieves:
+            raise NotImplementedError("Sieve Algorithm '%s' invalid. "%(alg) + "Please choose among "+str(valid_sieves) )
+
         if alg is None:
             if self.n < self.params.gauss_crossover:
                 alg = "gauss"
@@ -1266,19 +1278,16 @@ cdef class Siever(object):
         elif alg == "gauss":
             with tracer.context("gauss"):
                 self.gauss_sieve(reset_stats=reset_stats)
-        elif alg == "gauss_no_upd":
-            print "--alg gauss_no_upd has been renamed into just --alg gauss. the gauss_no_upd option will be removed soon." #TODO: Remove this line. It just serves to spot issues gracefully.
-            with tracer.context("gauss"):
-                self.gauss_sieve(reset_stats=reset_stats)
         elif alg == "gauss_triple_st":  #Single-threaded 3Sieve
             with tracer.context("triple_st"):
                 self.gauss_triple_sieve_st(reset_stats=reset_stats)
         elif alg == "gauss_triple_mt": #Multi-threaded 3Sieve, keep both for now
             with tracer.context("triple_mt"):
                 self.gauss_triple_mt(reset_stats=reset_stats)
-        # NOTE : There currently is no working gauss_triple without _no_upd, gauss_triple_no_upd might be renamed into gauss_triple
         else:
-            raise NotImplementedError("Algorithm `%s` of type %s not recognized"%(alg, type(alg)))
+            # The algorithm should have been preemptively checked
+            assert(False)
+            
 
     def extend_left(self, offset=1):
         """

--- a/g6k/utils/util.py
+++ b/g6k/utils/util.py
@@ -244,7 +244,7 @@ def db_stats(stats):
             "|db|", filter=lambda node: SieveTreeTracer.is_sieve_node(node.label), repr="max"
         ).max
 
-    return log(max_dbs.avg, 2), log(max_dbs.max, 2)
+    return log(max(1, max_dbs.avg), 2), log(max(1,max_dbs.max), 2)
 
 
 def load_lwe_challenge(n=40, alpha=0.005):

--- a/svp_exact.py
+++ b/svp_exact.py
@@ -83,7 +83,7 @@ def svp_kernel(arg0, params=None, seed=None):
         bkz_params = fplll_bkz.Param(block_size=n, max_loops=1, strategies=fplll_bkz.DEFAULT_STRATEGY,
                                      flags=fplll_bkz.GH_BND)
         svp_enum(bkz, bkz_params, goal_r0)
-        flast = -1
+        flast = 0
     elif alg == "duc18":
         assert len(workout_params) + len(pump_params) == 0
         flast = ducas18(g6k, tracer, goal=goal_r0)


### PR DESCRIPTION
The documentation was incorrect. The svp_exact.py allows to use FPLLL enumeration for comparison purposes, but this is done vial `--svp/alg enum'.

Also avoid a math error (log(0)) in util.
Also removed the deprecated "gauss_no_upd" name, that was redirecting to "gauss".