### PR TITLE
fixing doctest (int type issue)

### DIFF
--- a/g6k/siever.pyx
+++ b/g6k/siever.pyx
@@ -1575,8 +1575,8 @@ cdef class Siever(object):
             >>> g6k()
             >>> bl = g6k.best_lifts()
             >>> id, nrm, w = bl[0]
-            >>> id, round(nrm)
-            (0, 194629.0)
+            >>> id, int(round(nrm))
+            (0, 194629)
             >>> sum([v**2 for v in A.multiply_left(w)])
             194629
 


### PR DESCRIPTION
Behavior of `round` changed between python2 and python3, and now outputs an `int`