### PR TITLE
BDGL, mutex -> atomics

### DIFF
--- a/kernel/bdgl_sieve.cpp
+++ b/kernel/bdgl_sieve.cpp
@@ -249,7 +249,7 @@ void Siever::bdgl_process_buckets(const std::vector<uint32_t> &buckets, const st
     threadpool.wait_work();
 }
 
-void Siever::bdgl_queue_dup_remove_task( const size_t, std::vector<QEntry> &queue) {
+void Siever::bdgl_queue_dup_remove_task( std::vector<QEntry> &queue) {
     const size_t Q = queue.size();
     for( size_t index = 0; index < Q; index++ ) {
         size_t i1 = queue[index].i;
@@ -304,8 +304,8 @@ size_t Siever::bdgl_queue_insert_task( const size_t t_id, std::vector<Entry> &tr
 size_t Siever::bdgl_queue(std::vector<std::vector<QEntry>> &t_queues, std::vector<std::vector<Entry>>& transaction_db ) {
     // clear duplicates read only
     for( size_t t_id = 0; t_id < params.threads; ++t_id ) {
-        threadpool.push([this, t_id, &t_queues, &transaction_db](){
-            bdgl_queue_dup_remove_task(t_id, t_queues[t_id]);
+        threadpool.push([this, t_id, &t_queues](){
+            bdgl_queue_dup_remove_task(t_queues[t_id]);
         });
     }
     threadpool.wait_work();

--- a/kernel/bdgl_sieve.cpp
+++ b/kernel/bdgl_sieve.cpp
@@ -301,7 +301,7 @@ size_t Siever::bdgl_queue_insert_task( const size_t t_id, std::vector<Entry> &tr
     return kk + params.threads;
 }
 
-size_t Siever::bdgl_queue(std::vector<std::vector<QEntry>> &t_queues, std::vector<std::vector<Entry>>& transaction_db ) {
+void Siever::bdgl_queue(std::vector<std::vector<QEntry>> &t_queues, std::vector<std::vector<Entry>>& transaction_db ) {
     // clear duplicates read only
     for( size_t t_id = 0; t_id < params.threads; ++t_id ) {
         threadpool.push([this, t_id, &t_queues](){
@@ -331,11 +331,6 @@ size_t Siever::bdgl_queue(std::vector<std::vector<QEntry>> &t_queues, std::vecto
     }
     threadpool.wait_work(); 
 
-    size_t transaction_vecs_used = 0;
-    for(unsigned int t_id = 0; t_id < params.threads; t_id++ ) {
-        transaction_vecs_used += transaction_db[t_id].size()-1 - write_indices[t_id];
-    }
-
     // Insert transaction DB
     std::vector<size_t> kk(params.threads);
     for( size_t t_id = 0; t_id < params.threads; ++t_id ) {
@@ -351,8 +346,6 @@ size_t Siever::bdgl_queue(std::vector<std::vector<QEntry>> &t_queues, std::vecto
         inserted += (S-1-i - kk[i]-params.threads)/params.threads;
     }
     status_data.plain_data.sorted_until = min_kk;
-
-    return transaction_vecs_used;
 }
 
 bool Siever::bdgl_sieve(size_t nr_buckets_aim, const size_t blocks, const size_t multi_hash) {

--- a/kernel/siever.h
+++ b/kernel/siever.h
@@ -1075,9 +1075,9 @@ private:
                                 std::vector<std::vector<QEntry>> &t_queues);
     
     void bdgl_queue_create_task( const size_t t_id, const std::vector<QEntry> &queue, std::vector<Entry> &transaction_dbi, int64_t &write_index);
-    void bdgl_queue_dup_remove_task( const size_t t_id, std::vector<QEntry> &queue);
+    void bdgl_queue_dup_remove_task( std::vector<QEntry> &queue);
     size_t bdgl_queue_insert_task( const size_t t_id, std::vector<Entry> &transaction_dbi, int64_t write_index);
-    size_t bdgl_queue( std::vector<std::vector<QEntry>> &t_queues, std::vector<std::vector<Entry>> &transaction_db);
+    void bdgl_queue( std::vector<std::vector<QEntry>> &t_queues, std::vector<std::vector<Entry>> &transaction_db);
 
     std::pair<LFT, int8_t> reduce_to_QEntry(CompressedEntry *ce1, CompressedEntry *ce2);
 

--- a/kernel/siever.h
+++ b/kernel/siever.h
@@ -108,6 +108,7 @@ using SimHashDescriptor = unsigned[XPC_BIT_LEN][6]; // typedef to avoid some awk
 struct Entry;
 struct QEntry;
 struct CompressedEntry;
+struct atomic_size_t_wrapper;
 class Siever;
 class UidHashTable;
 class SimHashes;
@@ -1064,14 +1065,14 @@ private:
     bool bdgl_replace_in_db(size_t cdb_index, Entry &e);
 
     void bdgl_bucketing_task(const size_t t_id, 
-                             std::vector<uint32_t> &buckets, std::vector<size_t> &buckets_index,
+                             std::vector<uint32_t> &buckets, std::vector<atomic_size_t_wrapper> &buckets_index,
                              ProductLSH &lsh);
     void bdgl_bucketing(const size_t blocks, const size_t multi_hash, const size_t nr_buckets_aim, 
-                        std::vector<uint32_t> &buckets, std::vector<size_t> &buckets_index);
+                        std::vector<uint32_t> &buckets, std::vector<atomic_size_t_wrapper> &buckets_index);
 
     void bdgl_process_buckets_task(const size_t t_id, const std::vector<uint32_t> &buckets, 
-                                   const std::vector<size_t> &buckets_index, std::vector<QEntry> &t_queue);
-    void bdgl_process_buckets(const std::vector<uint32_t> &buckets, const std::vector<size_t> &buckets_index,
+                                   const std::vector<atomic_size_t_wrapper> &buckets_index, std::vector<QEntry> &t_queue);
+    void bdgl_process_buckets(const std::vector<uint32_t> &buckets, const std::vector<atomic_size_t_wrapper> &buckets_index,
                                 std::vector<std::vector<QEntry>> &t_queues);
     
     void bdgl_queue_create_task( const size_t t_id, const std::vector<QEntry> &queue, std::vector<Entry> &transaction_dbi, int64_t &write_index);
@@ -1080,10 +1081,6 @@ private:
     void bdgl_queue( std::vector<std::vector<QEntry>> &t_queues, std::vector<std::vector<Entry>> &transaction_db);
 
     std::pair<LFT, int8_t> reduce_to_QEntry(CompressedEntry *ce1, CompressedEntry *ce2);
-
-    // bdgl variables
-    static constexpr unsigned BDGL_BUCKET_SPLIT = 512;
-    std::array<std::mutex, BDGL_BUCKET_SPLIT> bdgl_bucket_mut;
 
 // previously, these were global variables. TODO: Document / refactor those.
     CACHELINE_VARIABLE(std::atomic_size_t, GBL_replace_pos);


### PR DESCRIPTION
This pull request replaces the use of mutexes for incrementing bucket counters by atomics.
No observable performance differences but the code is a bit cleaner now.

The wrapper is needed to prevent problems with the copy constructor when using an atomic in a std::vector.