### PR TITLE
Maximum sieving dimension checks

### DIFF
--- a/full_sieve.py
+++ b/full_sieve.py
@@ -34,17 +34,6 @@ def full_sieve_kernel(arg0, params=None, seed=None):
     A, _ = load_svpchallenge_and_randomize(n, s=challenge_seed, seed=seed)
 
     g6k = Siever(A, params, seed=seed)
-
-    if g6k.dimension_bigger_than_msd():
-        print("Error: this is an unsafe sieving instance.")
-        print(
-            "This is because the dimension of the lattice > the maximum supported dimension."
-        )
-        print(
-            "To fix this issue, please recompile with a higher maximum sieving dimension using rebuild.sh"
-        )
-        exit()
-
     tracer = SieveTreeTracer(g6k, root_label=("full-sieve", n), start_clocks=True)
 
     # Actually runs a workout with very large decrements, so that the basis is kind-of reduced

--- a/full_sieve.py
+++ b/full_sieve.py
@@ -33,7 +33,15 @@ def full_sieve_kernel(arg0, params=None, seed=None):
     challenge_seed = params.pop("challenge_seed")
     A, _ = load_svpchallenge_and_randomize(n, s=challenge_seed, seed=seed)
 
+
     g6k = Siever(A, params, seed=seed)
+
+    if g6k.dimension_bigger_than_msd():
+        print("Error: this is an unsafe sieving instance.")
+        print("This is because the dimension of the lattice > the maximum supported dimension.")
+        print("To fix this issue, please recompile with a higher maximum sieving dimension using rebuild.sh")
+        exit()
+
     tracer = SieveTreeTracer(g6k, root_label=("full-sieve", n), start_clocks=True)
 
     # Actually runs a workout with very large decrements, so that the basis is kind-of reduced

--- a/full_sieve.py
+++ b/full_sieve.py
@@ -33,20 +33,32 @@ def full_sieve_kernel(arg0, params=None, seed=None):
     challenge_seed = params.pop("challenge_seed")
     A, _ = load_svpchallenge_and_randomize(n, s=challenge_seed, seed=seed)
 
-
     g6k = Siever(A, params, seed=seed)
 
     if g6k.dimension_bigger_than_msd():
         print("Error: this is an unsafe sieving instance.")
-        print("This is because the dimension of the lattice > the maximum supported dimension.")
-        print("To fix this issue, please recompile with a higher maximum sieving dimension using rebuild.sh")
+        print(
+            "This is because the dimension of the lattice > the maximum supported dimension."
+        )
+        print(
+            "To fix this issue, please recompile with a higher maximum sieving dimension using rebuild.sh"
+        )
         exit()
 
     tracer = SieveTreeTracer(g6k, root_label=("full-sieve", n), start_clocks=True)
 
     # Actually runs a workout with very large decrements, so that the basis is kind-of reduced
     # for the final full-sieve
-    workout(g6k, tracer, 0, n, dim4free_min=0, dim4free_dec=15, pump_params=pump_params, verbose=verbose)
+    workout(
+        g6k,
+        tracer,
+        0,
+        n,
+        dim4free_min=0,
+        dim4free_dec=15,
+        pump_params=pump_params,
+        verbose=verbose,
+    )
 
     return tracer.exit()
 
@@ -57,31 +69,42 @@ def full_sieve():
     """
     description = full_sieve.__doc__
 
-    args, all_params = parse_args(description,
-                                  challenge_seed=0)
+    args, all_params = parse_args(description, challenge_seed=0)
 
-    stats = run_all(full_sieve_kernel, list(all_params.values()),
-                    lower_bound=args.lower_bound,
-                    upper_bound=args.upper_bound,
-                    step_size=args.step_size,
-                    trials=args.trials,
-                    workers=args.workers,
-                    seed=args.seed
-                    )
+    stats = run_all(
+        full_sieve_kernel,
+        list(all_params.values()),
+        lower_bound=args.lower_bound,
+        upper_bound=args.upper_bound,
+        step_size=args.step_size,
+        trials=args.trials,
+        workers=args.workers,
+        seed=args.seed,
+    )
 
     inverse_all_params = OrderedDict([(v, k) for (k, v) in six.iteritems(all_params)])
     stats = sanitize_params_names(stats, inverse_all_params)
 
     fmt = "{name:50s} :: n: {n:2d}, cputime {cputime:7.4f}s, walltime: {walltime:7.4f}s, |db|: 2^{avg_max:.2f}"
-    profiles = print_stats(fmt, stats, ("cputime", "walltime", "avg_max"),
-                           extractf={"avg_max": lambda n, params, stat: db_stats(stat)[0]})
+    profiles = print_stats(
+        fmt,
+        stats,
+        ("cputime", "walltime", "avg_max"),
+        extractf={"avg_max": lambda n, params, stat: db_stats(stat)[0]},
+    )
 
     output_profiles(args.profile, profiles)
 
     if args.pickle:
-        pickler.dump(stats, open("full-sieve-%d-%d-%d-%d.sobj" %
-                                 (args.lower_bound, args.upper_bound, args.step_size, args.trials), "wb"))
+        pickler.dump(
+            stats,
+            open(
+                "full-sieve-%d-%d-%d-%d.sobj"
+                % (args.lower_bound, args.upper_bound, args.step_size, args.trials),
+                "wb",
+            ),
+        )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     full_sieve()

--- a/g6k/algorithms/pump.py
+++ b/g6k/algorithms/pump.py
@@ -125,6 +125,8 @@ def pump(g6k, tracer, kappa, blocksize, dim4free, down_sieve=False,             
             pump.phase = "up"
             # Pump Up
             while (g6k.l > pump.l):
+                if(g6k.n + 1 > g6k.max_sieving_dim):
+                    raise RuntimeError("The current sieving context is bigger than maximum supported dimension.")
                 g6k.extend_left(1)
 
                 if verbose:

--- a/g6k/decl.pxd
+++ b/g6k/decl.pxd
@@ -20,6 +20,8 @@ cdef extern from "../kernel/siever.h" nogil:
     cdef const long int BGJ1_ALPHA_STEP
     cdef const long int CACHE_BLOCK
 
+    cdef const int  MAX_SIEVING_DIM
+
     ctypedef double FT
     ctypedef float  LFT
     ctypedef int16_t ZT

--- a/g6k/siever.pyx
+++ b/g6k/siever.pyx
@@ -297,7 +297,7 @@ cdef class Siever(object):
         """
         The maximum sieving dimension that's supported in this build of G6K.
         This value can be changed in the following ways:
-            - Manually. You can simply change the MAX_SIEVING_DIM macro in siever.h and then recompile.
+            - Manually. You can simply change the ``MAX_SIEVING_DIM`` macro in siever.h and then recompile.
 
             - Automatically. You can change this value by supplying the "-m <dim>" flag to rebuild.sh,
               where <dim> is the maximum supported dimension. For nicer support with AVX/vectorisation,

--- a/g6k/siever.pyx
+++ b/g6k/siever.pyx
@@ -297,10 +297,11 @@ cdef class Siever(object):
         """
         The maximum sieving dimension that's supported in this build of G6K.
         This value can be changed in the following ways:
-            - Manually. You can simply change the "MAX_SIEVING_DIM" macro in siever.h
+            - Manually. You can simply change the MAX_SIEVING_DIM macro in siever.h and then recompile.
+
             - Automatically. You can change this value by supplying the "-m <dim>" flag to rebuild.sh,
               where <dim> is the maximum supported dimension. For nicer support with AVX/vectorisation,
-              we recommend a multiple of 32.
+              we recommend a multiple of 32. This will recompile the g6k kernel.
               Example:
                 ./rebuild -m 160
         EXAMPLE::

--- a/g6k/siever.pyx
+++ b/g6k/siever.pyx
@@ -104,7 +104,7 @@ cdef class Siever(object):
         self._core.full_n = M.d
         
         if self._core.full_n > self.max_sieving_dim:
-            warnings.warn("Dimension of lattice is larger than maximum supported. To fix this warning, change the value of MAX_SIEVING_DIM in siever.h")
+            warnings.warn("Dimension of lattice is larger than maximum supported. To fix this warning, change the value of MAX_SIEVING_DIM in siever.h and recompile.")
 
         self.lll(0, M.d)
         self.initialized = False

--- a/g6k/siever.pyx
+++ b/g6k/siever.pyx
@@ -479,8 +479,6 @@ cdef class Siever(object):
 
     def reset_stats(self):
         self._core.reset_stats()
-    def dimension_bigger_than_maximum_sieving_dimension(self):
-        return self.M.d > MAX_SIEVING_DIM
     ############# New statistics ############
 
     # This exports _core.statistics to python. Note that stats(self) and get_stat(self, name)

--- a/g6k/siever.pyx
+++ b/g6k/siever.pyx
@@ -24,6 +24,7 @@ from math import ceil, floor
 
 from decl cimport CompressedEntry, Entry
 from decl cimport show_cpu_stats
+from decl cimport MAX_SIEVING_DIM
 
 from scipy.special import betaincinv
 
@@ -99,11 +100,11 @@ cdef class Siever(object):
             seed = IntegerMatrix.random(1, "uniform", bits=32)[0, 0]
         self._core = new Siever_c(params._core, <unsigned long>seed)
         self.params = copy.copy(params)
-
+        
         self._core.full_n = M.d
         self.lll(0, M.d)
         self.initialized = False
-
+    
     @classmethod
     def MatGSO(cls, A, float_type="d"):
         """
@@ -453,7 +454,8 @@ cdef class Siever(object):
 
     def reset_stats(self):
         self._core.reset_stats()
-
+    def dimension_bigger_than_msd(self):
+        return self.M.d > MAX_SIEVING_DIM
     ############# New statistics ############
 
     # This exports _core.statistics to python. Note that stats(self) and get_stat(self, name)

--- a/g6k/siever_params.pyx
+++ b/g6k/siever_params.pyx
@@ -5,6 +5,9 @@ Sieving parameters.
 
 from contextlib import contextmanager
 from pkg_resources import resource_filename
+from decl cimport MAX_SIEVING_DIM
+
+import warnings
 
 @contextmanager
 def temp_params(self, **kwds):
@@ -145,6 +148,8 @@ cdef class SieverParams(object):
             raise ValueError("This object is read only, create a copy to edit.")
 
         if key == "reserved_n":
+            if value > MAX_SIEVING_DIM:
+                warnings.warn("reserved_n is larger than maximum supported. To fix this warning, change the value of MAX_SIEVING_DIM in siever.h")
             self._core.reserved_n = value
         elif key == "reserved_db_size":
             self._core.reserved_db_size = value

--- a/g6k/siever_params.pyx
+++ b/g6k/siever_params.pyx
@@ -149,7 +149,7 @@ cdef class SieverParams(object):
 
         if key == "reserved_n":
             if value > MAX_SIEVING_DIM:
-                warnings.warn("reserved_n is larger than maximum supported. To fix this warning, change the value of MAX_SIEVING_DIM in siever.h")
+                warnings.warn("reserved_n is larger than maximum supported. To fix this warning, change the value of MAX_SIEVING_DIM in siever.h and recompile.")
             self._core.reserved_n = value
         elif key == "reserved_db_size":
             self._core.reserved_db_size = value

--- a/plain_sieve.py
+++ b/plain_sieve.py
@@ -33,17 +33,6 @@ def plain_sieve_kernel(arg0, params=None, seed=None):
 
     A, _ = load_svpchallenge_and_randomize(n, s=0, seed=seed)
     g6k = Siever(A, params, seed=seed)
-
-    if g6k.dimension_bigger_than_msd():
-        print("Error: this is an unsafe sieving instance.")
-        print(
-            "This is because the dimension of the lattice > the maximum supported dimension."
-        )
-        print(
-            "To fix this issue, please recompile with a higher maximum sieving dimension using rebuild.sh"
-        )
-        exit()
-
     tracer = SieveTreeTracer(g6k, root_label=("plain-sieve", n), start_clocks=True)
     g6k.initialize_local(0, 0, n)
     g6k(alg=alg, tracer=tracer)

--- a/plain_sieve.py
+++ b/plain_sieve.py
@@ -36,11 +36,13 @@ def plain_sieve_kernel(arg0, params=None, seed=None):
 
     if g6k.dimension_bigger_than_msd():
         print("Error: this is an unsafe sieving instance.")
-        print("This is because the dimension of the lattice > the maximum supported dimension.")
-        print("To fix this issue, please recompile with a higher maximum sieving dimension using rebuild.sh")
+        print(
+            "This is because the dimension of the lattice > the maximum supported dimension."
+        )
+        print(
+            "To fix this issue, please recompile with a higher maximum sieving dimension using rebuild.sh"
+        )
         exit()
-
-
 
     tracer = SieveTreeTracer(g6k, root_label=("plain-sieve", n), start_clocks=True)
     g6k.initialize_local(0, 0, n)
@@ -55,15 +57,18 @@ def plain_sieve():
     """
     description = plain_sieve.__doc__
 
-    args, all_params = parse_args(description,)
+    args, all_params = parse_args(description)
 
-    stats = run_all(plain_sieve_kernel, list(all_params.values()),
-                    lower_bound=args.lower_bound,
-                    upper_bound=args.upper_bound,
-                    step_size=args.step_size,
-                    trials=args.trials,
-                    workers=args.workers,
-                    seed=args.seed)
+    stats = run_all(
+        plain_sieve_kernel,
+        list(all_params.values()),
+        lower_bound=args.lower_bound,
+        upper_bound=args.upper_bound,
+        step_size=args.step_size,
+        trials=args.trials,
+        workers=args.workers,
+        seed=args.seed,
+    )
 
     inverse_all_params = OrderedDict([(v, k) for (k, v) in six.iteritems(all_params)])
 
@@ -71,15 +76,25 @@ def plain_sieve():
     stats = sanitize_params_names(stats, inverse_all_params)
 
     fmt = "{name:50s} :: n: {n:2d}, cputime {cputime:7.4f}s, walltime: {walltime:7.4f}s, |db|: 2^{avg_max:.2f}"
-    profiles = print_stats(fmt, stats, ("cputime", "walltime", "avg_max"),
-                           extractf={"avg_max": lambda n, params, stat: db_stats(stat)[0]})
+    profiles = print_stats(
+        fmt,
+        stats,
+        ("cputime", "walltime", "avg_max"),
+        extractf={"avg_max": lambda n, params, stat: db_stats(stat)[0]},
+    )
 
     output_profiles(args.profile, profiles)
 
     if args.pickle:
-        pickler.dump(stats, open("plain-sieve-%d-%d-%d-%d.sobj" %
-                                 (args.lower_bound, args.upper_bound, args.step_size, args.trials), "wb"))
+        pickler.dump(
+            stats,
+            open(
+                "plain-sieve-%d-%d-%d-%d.sobj"
+                % (args.lower_bound, args.upper_bound, args.step_size, args.trials),
+                "wb",
+            ),
+        )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     plain_sieve()

--- a/plain_sieve.py
+++ b/plain_sieve.py
@@ -33,6 +33,15 @@ def plain_sieve_kernel(arg0, params=None, seed=None):
 
     A, _ = load_svpchallenge_and_randomize(n, s=0, seed=seed)
     g6k = Siever(A, params, seed=seed)
+
+    if g6k.dimension_bigger_than_msd():
+        print("Error: this is an unsafe sieving instance.")
+        print("This is because the dimension of the lattice > the maximum supported dimension.")
+        print("To fix this issue, please recompile with a higher maximum sieving dimension using rebuild.sh")
+        exit()
+
+
+
     tracer = SieveTreeTracer(g6k, root_label=("plain-sieve", n), start_clocks=True)
     g6k.initialize_local(0, 0, n)
     g6k(alg=alg, tracer=tracer)

--- a/svp_challenge.py
+++ b/svp_challenge.py
@@ -53,6 +53,15 @@ def asvp_kernel(arg0, params=None, seed=None):
             print(("Loaded file '%s'" % load_matrix))
 
     g6k = Siever(A, params, seed=seed)
+
+    if g6k.dimension_bigger_than_msd():
+        print("Warning: potentially unsafe sieving instance.")
+        print("This is because the dimension of the lattice > the maximum supported dimension.")
+        print("However, this may not be an issue for your input lattice when taking dimensions for free into account")
+        print("To fix this issue, please recompile with a higher maximum sieving dimension using rebuild.sh")
+
+
+
     tracer = SieveTreeTracer(g6k, root_label=("svp-challenge", n), start_clocks=True)
 
     gh = gaussian_heuristic([g6k.M.get_r(i, i) for i in range(n)])

--- a/svp_challenge.py
+++ b/svp_challenge.py
@@ -25,7 +25,7 @@ from six.moves import range
 
 
 def asvp_kernel(arg0, params=None, seed=None):
-    logger = logging.getLogger('asvp')
+    logger = logging.getLogger("asvp")
 
     # Pool.map only supports a single parameter
     if params is None and seed is None:
@@ -56,21 +56,31 @@ def asvp_kernel(arg0, params=None, seed=None):
 
     if g6k.dimension_bigger_than_msd():
         print("Warning: potentially unsafe sieving instance.")
-        print("This is because the dimension of the lattice > the maximum supported dimension.")
-        print("However, this may not be an issue for your input lattice when taking dimensions for free into account")
-        print("To fix this issue, please recompile with a higher maximum sieving dimension using rebuild.sh")
-
-
+        print(
+            "This is because the dimension of the lattice > the maximum supported dimension."
+        )
+        print(
+            "However, this may not be an issue for your input lattice when taking dimensions for free into account"
+        )
+        print(
+            "To fix this issue, please recompile with a higher maximum sieving dimension using rebuild.sh"
+        )
 
     tracer = SieveTreeTracer(g6k, root_label=("svp-challenge", n), start_clocks=True)
 
     gh = gaussian_heuristic([g6k.M.get_r(i, i) for i in range(n)])
-    goal_r0 = (1.05**2) * gh
+    goal_r0 = (1.05 ** 2) * gh
     if verbose:
-        print(("gh = %f, goal_r0/gh = %f, r0/gh = %f" % (gh, goal_r0/gh, sum([x*x for x in A[0]])/gh)))
+        print(
+            (
+                "gh = %f, goal_r0/gh = %f, r0/gh = %f"
+                % (gh, goal_r0 / gh, sum([x * x for x in A[0]]) / gh)
+            )
+        )
 
-    flast = workout(g6k, tracer, 0, n, goal_r0=goal_r0,
-                    pump_params=pump_params, **workout_params)
+    flast = workout(
+        g6k, tracer, 0, n, goal_r0=goal_r0, pump_params=pump_params, **workout_params
+    )
 
     tracer.exit()
     stat = tracer.trace
@@ -79,9 +89,9 @@ def asvp_kernel(arg0, params=None, seed=None):
     if verbose:
         logger.info("sol %d, %s" % (n, A[0]))
 
-    norm = sum([x*x for x in A[0]])
+    norm = sum([x * x for x in A[0]])
     if verbose:
-        logger.info("norm %.1f ,hf %.5f" % (norm**.5, (norm/gh)**.5))
+        logger.info("norm %.1f ,hf %.5f" % (norm ** 0.5, (norm / gh) ** 0.5))
 
     return tracer.trace
 
@@ -92,32 +102,48 @@ def asvp():
     """
     description = asvp.__doc__
 
-    args, all_params = parse_args(description,
-                                  load_matrix=None,
-                                  verbose=True,
-                                  challenge_seed=0,
-                                  workout__dim4free_dec=3)
+    args, all_params = parse_args(
+        description,
+        load_matrix=None,
+        verbose=True,
+        challenge_seed=0,
+        workout__dim4free_dec=3,
+    )
 
-    stats = run_all(asvp_kernel, list(all_params.values()),
-                    lower_bound=args.lower_bound,
-                    upper_bound=args.upper_bound,
-                    step_size=args.step_size,
-                    trials=args.trials,
-                    workers=args.workers,
-                    seed=args.seed)
+    stats = run_all(
+        asvp_kernel,
+        list(all_params.values()),
+        lower_bound=args.lower_bound,
+        upper_bound=args.upper_bound,
+        step_size=args.step_size,
+        trials=args.trials,
+        workers=args.workers,
+        seed=args.seed,
+    )
 
     inverse_all_params = OrderedDict([(v, k) for (k, v) in six.iteritems(all_params)])
     stats = sanitize_params_names(stats, inverse_all_params)
 
     fmt = "{name:50s} :: n: {n:2d}, cputime {cputime:7.4f}s, walltime: {walltime:7.4f}s, flast: {flast:3.2f}, |db|: 2^{avg_max:.2f}"
-    profiles = print_stats(fmt, stats, ("cputime", "walltime", "flast", "avg_max"),
-                           extractf={"avg_max": lambda n, params, stat: db_stats(stat)[0]})
+    profiles = print_stats(
+        fmt,
+        stats,
+        ("cputime", "walltime", "flast", "avg_max"),
+        extractf={"avg_max": lambda n, params, stat: db_stats(stat)[0]},
+    )
 
     output_profiles(args.profile, profiles)
 
     if args.pickle:
-        pickler.dump(stats, open("svp-challenge-%d-%d-%d-%d.sobj" %
-                                 (args.lower_bound, args.upper_bound, args.step_size, args.trials), "wb"))
+        pickler.dump(
+            stats,
+            open(
+                "svp-challenge-%d-%d-%d-%d.sobj"
+                % (args.lower_bound, args.upper_bound, args.step_size, args.trials),
+                "wb",
+            ),
+        )
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     asvp()

--- a/svp_challenge.py
+++ b/svp_challenge.py
@@ -53,19 +53,6 @@ def asvp_kernel(arg0, params=None, seed=None):
             print(("Loaded file '%s'" % load_matrix))
 
     g6k = Siever(A, params, seed=seed)
-
-    if g6k.dimension_bigger_than_msd():
-        print("Warning: potentially unsafe sieving instance.")
-        print(
-            "This is because the dimension of the lattice > the maximum supported dimension."
-        )
-        print(
-            "However, this may not be an issue for your input lattice when taking dimensions for free into account"
-        )
-        print(
-            "To fix this issue, please recompile with a higher maximum sieving dimension using rebuild.sh"
-        )
-
     tracer = SieveTreeTracer(g6k, root_label=("svp-challenge", n), start_clocks=True)
 
     gh = gaussian_heuristic([g6k.M.get_r(i, i) for i in range(n)])

--- a/svp_exact.py
+++ b/svp_exact.py
@@ -82,19 +82,6 @@ def svp_kernel(arg0, params=None, seed=None):
     goal_r0 = 1.001 * load_svpchallenge_norm(n, s=challenge_seed)
     A, bkz = load_svpchallenge_and_randomize(n, s=challenge_seed, seed=seed)
     g6k = Siever(A, params, seed=seed)
-
-    if g6k.dimension_bigger_than_msd():
-        print("Warning: potentially unsafe sieving instance.")
-        print(
-            "This is because the dimension of the lattice > the maximum supported dimension."
-        )
-        print(
-            "However, this may not be an issue for your input lattice when taking dimensions for free into account"
-        )
-        print(
-            "To fix this issue, please recompile with a higher maximum sieving dimension using rebuild.sh"
-        )
-
     tracer = SieveTreeTracer(g6k, root_label=("svp-exact", n), start_clocks=True)
 
     if alg == "enum":

--- a/svp_exact.py
+++ b/svp_exact.py
@@ -16,7 +16,11 @@ from g6k.algorithms.workout import workout
 from g6k.siever import Siever
 from g6k.utils.cli import parse_args, run_all, pop_prefixed_params
 from g6k.utils.stats import SieveTreeTracer
-from g6k.utils.util import load_svpchallenge_and_randomize, load_svpchallenge_norm, db_stats
+from g6k.utils.util import (
+    load_svpchallenge_and_randomize,
+    load_svpchallenge_norm,
+    db_stats,
+)
 from g6k.utils.util import sanitize_params_names, print_stats, output_profiles
 
 
@@ -28,7 +32,7 @@ from six.moves import range
 
 
 GRADIENT_BLOCKSIZE = 31
-NPS = 60*[2.**29] + 5 * [2.**27] + 5 * [2.**26] + 1000 * [2.**25]
+NPS = 60 * [2.0 ** 29] + 5 * [2.0 ** 27] + 5 * [2.0 ** 26] + 1000 * [2.0 ** 25]
 
 
 # Re-implement bkz2.svp_reduction, with a precise radius goal rather than success proba
@@ -49,7 +53,9 @@ def svp_enum(bkz, params, goal):
 
         try:
             enum_obj = Enumeration(bkz.M)
-            max_dist, solution = enum_obj.enumerate(0, n, radius, 0, pruning=pruning.coefficients)[0]
+            max_dist, solution = enum_obj.enumerate(
+                0, n, radius, 0, pruning=pruning.coefficients
+            )[0]
             bkz.svp_postprocessing(0, n, solution, tracer=dummy_tracer)
             rerandomize = False
         except EnumerationError:
@@ -76,27 +82,54 @@ def svp_kernel(arg0, params=None, seed=None):
     goal_r0 = 1.001 * load_svpchallenge_norm(n, s=challenge_seed)
     A, bkz = load_svpchallenge_and_randomize(n, s=challenge_seed, seed=seed)
     g6k = Siever(A, params, seed=seed)
+
+    if g6k.dimension_bigger_than_msd():
+        print("Warning: potentially unsafe sieving instance.")
+        print(
+            "This is because the dimension of the lattice > the maximum supported dimension."
+        )
+        print(
+            "However, this may not be an issue for your input lattice when taking dimensions for free into account"
+        )
+        print(
+            "To fix this issue, please recompile with a higher maximum sieving dimension using rebuild.sh"
+        )
+
     tracer = SieveTreeTracer(g6k, root_label=("svp-exact", n), start_clocks=True)
 
     if alg == "enum":
         assert len(workout_params) + len(pump_params) == 0
-        bkz_params = fplll_bkz.Param(block_size=n, max_loops=1, strategies=fplll_bkz.DEFAULT_STRATEGY,
-                                     flags=fplll_bkz.GH_BND)
+        bkz_params = fplll_bkz.Param(
+            block_size=n,
+            max_loops=1,
+            strategies=fplll_bkz.DEFAULT_STRATEGY,
+            flags=fplll_bkz.GH_BND,
+        )
         svp_enum(bkz, bkz_params, goal_r0)
         flast = 0
     elif alg == "duc18":
         assert len(workout_params) + len(pump_params) == 0
         flast = ducas18(g6k, tracer, goal=goal_r0)
     elif alg == "workout":
-        flast = workout(g6k, tracer, 0, n, goal_r0=goal_r0, pump_params=pump_params, **workout_params)
+        flast = workout(
+            g6k,
+            tracer,
+            0,
+            n,
+            goal_r0=goal_r0,
+            pump_params=pump_params,
+            **workout_params
+        )
     else:
         raise ValueError("Unrecognized algorithm for SVP")
 
     r0 = bkz.M.get_r(0, 0) if alg == "enum" else g6k.M.get_r(0, 0)
     if r0 > goal_r0:
-        raise ValueError('Did not reach the goal')
+        raise ValueError("Did not reach the goal")
     if 1.002 * r0 < goal_r0:
-        raise ValueError('Found a vector shorter than the goal for n=%d s=%d.'%(n, challenge_seed))
+        raise ValueError(
+            "Found a vector shorter than the goal for n=%d s=%d." % (n, challenge_seed)
+        )
 
     tracer.exit()
     stat = tracer.trace
@@ -113,32 +146,42 @@ def svp():
     """
     description = svp.__doc__
 
-    args, all_params = parse_args(description,
-                                  challenge_seed=0,
-                                  svp__alg="workout"
-                                  )
+    args, all_params = parse_args(description, challenge_seed=0, svp__alg="workout")
 
-    stats = run_all(svp_kernel, list(all_params.values()),
-                    lower_bound=args.lower_bound,
-                    upper_bound=args.upper_bound,
-                    step_size=args.step_size,
-                    trials=args.trials,
-                    workers=args.workers,
-                    seed=args.seed)
+    stats = run_all(
+        svp_kernel,
+        list(all_params.values()),
+        lower_bound=args.lower_bound,
+        upper_bound=args.upper_bound,
+        step_size=args.step_size,
+        trials=args.trials,
+        workers=args.workers,
+        seed=args.seed,
+    )
 
     inverse_all_params = OrderedDict([(v, k) for (k, v) in six.iteritems(all_params)])
     stats = sanitize_params_names(stats, inverse_all_params)
 
     fmt = "{name:50s} :: n: {n:2d}, cputime {cputime:7.4f}s, walltime: {walltime:7.4f}s, flast: {flast:3.2f}, |db|: 2^{avg_max:.2f}"
-    profiles = print_stats(fmt, stats, ("cputime", "walltime", "flast", "avg_max"),
-                           extractf={"avg_max": lambda n, params, stat: db_stats(stat)[0]})
+    profiles = print_stats(
+        fmt,
+        stats,
+        ("cputime", "walltime", "flast", "avg_max"),
+        extractf={"avg_max": lambda n, params, stat: db_stats(stat)[0]},
+    )
 
     output_profiles(args.profile, profiles)
 
     if args.pickle:
-        pickler.dump(stats, open("svp-exact-%d-%d-%d-%d.sobj" %
-                                 (args.lower_bound, args.upper_bound, args.step_size, args.trials), "wb"))
+        pickler.dump(
+            stats,
+            open(
+                "svp-exact-%d-%d-%d-%d.sobj"
+                % (args.lower_bound, args.upper_bound, args.step_size, args.trials),
+                "wb",
+            ),
+        )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     svp()


### PR DESCRIPTION
## What's the problem?
I recently realised that the user is never warned if their sieving instance is bigger than the maximum supported (i.e if ``M.d > MAX_SIEVING_DIM``). This is particularly unfortunate because their programs would crash after doing a lot of expensive work.

## What's the solution?
This PR does the following:

- Adds a function to the ``Siever`` object, ``dimension_bigger_than_msd``. This can be used to query if the sieving operation is potentially unsafe. This function is what the code from the outside world would call.
- Adds these checks to ``full_sieve.py``, ``plain_sieve.py``, ``svp_exact.py`` and ``svp_challenge.py``. In the case of the first two, the program will exit with an error. By contrast, the last two merely issue a warning. 


 