### PR TITLE
remove hardcoded -march=native

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -59,8 +59,8 @@ $PIP install cysignals
 
 
 cat <<EOF >>g6k-env/bin/activate
-CFLAGS="\$CFLAGS -O3 -march=native -Wp,-U_FORTIFY_SOURCE"
-CXXFLAGS="\$CXXFLAGS -O3 -march=native -Wp,-U_FORTIFY_SOURCE"
+CFLAGS="\$CFLAGS -O3 -Wp,-U_FORTIFY_SOURCE"
+CXXFLAGS="\$CXXFLAGS -O3 -Wp,-U_FORTIFY_SOURCE"
 export CFLAGS
 export CXXFLAGS
 EOF

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -59,8 +59,8 @@ $PIP install cysignals
 
 
 cat <<EOF >>g6k-env/bin/activate
-CFLAGS="\$CFLAGS -O3 -Wp,-U_FORTIFY_SOURCE"
-CXXFLAGS="\$CXXFLAGS -O3 -Wp,-U_FORTIFY_SOURCE"
+CFLAGS="\$CFLAGS -O3 -march=native -Wp,-U_FORTIFY_SOURCE"
+CXXFLAGS="\$CXXFLAGS -O3 -march=native -Wp,-U_FORTIFY_SOURCE"
 export CFLAGS
 export CXXFLAGS
 EOF

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -1,4 +1,4 @@
-CXXFLAGS += -fPIC -Ofast -ftree-vectorize -funroll-loops -std=c++11 -pthread -Wall -Wextra $(EXTRAFLAGS)
+CXXFLAGS += -fPIC -Ofast -mavx2 -ftree-vectorize -funroll-loops -std=c++11 -pthread -Wall -Wextra $(EXTRAFLAGS)
 LDFLAGS += -shared -pthread
 LIBADD += -lpthread
 OBJ = sieving.o control.o bgj1_sieve.o bdgl_sieve.o fht_lsh.o params.o cpuperf.o hk3_sieve.o

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -1,4 +1,4 @@
-CXXFLAGS += -fPIC -Ofast -march=native -ftree-vectorize -funroll-loops -std=c++11 -pthread -Wall -Wextra $(EXTRAFLAGS)
+CXXFLAGS += -fPIC -Ofast -ftree-vectorize -funroll-loops -std=c++11 -pthread -Wall -Wextra $(EXTRAFLAGS)
 LDFLAGS += -shared -pthread
 LIBADD += -lpthread
 OBJ = sieving.o control.o bgj1_sieve.o bdgl_sieve.o fht_lsh.o params.o cpuperf.o hk3_sieve.o

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -1,4 +1,4 @@
-CXXFLAGS += -fPIC -Ofast -mavx2 -ftree-vectorize -funroll-loops -std=c++11 -pthread -Wall -Wextra $(EXTRAFLAGS)
+CXXFLAGS += -fPIC -Ofast -mavx2 -maes -ftree-vectorize -funroll-loops -std=c++11 -pthread -Wall -Wextra $(EXTRAFLAGS)
 LDFLAGS += -shared -pthread
 LIBADD += -lpthread
 OBJ = sieving.o control.o bgj1_sieve.o bdgl_sieve.o fht_lsh.o params.o cpuperf.o hk3_sieve.o


### PR DESCRIPTION
This might be controversial, but hardcoding `-march=native` makes binary distribution hard.