### PR TITLE
Don't compute inner products twice

### DIFF
--- a/kernel/siever.h
+++ b/kernel/siever.h
@@ -1037,11 +1037,11 @@ private:
     // This is only needed for statistical purposes and the paramter is only passed if it is needed.
     // The #if condition is an ugly hack, but this ensures that we have zero performance loss in case we do not collect statistics.
     #if (COLLECT_STATISTICS_OTFLIFTS >= 2) || (COLLECT_STATISTICS_REDSUCCESS >= 2) || (COLLECT_STATISTICS_DATARACES >= 2)
-    template <int tn>
-    inline bool bgj1_reduce_with_delayed_replace(CompressedEntry const &ce1, CompressedEntry const &ce2, LFT lenbound, std::vector<Entry>& transaction_db, bool reduce_while_bucketing = true); // in bgj1_sieve.cpp
+    template <int tn, bool use_inner>
+    inline bool bgj1_reduce_with_delayed_replace(CompressedEntry const &ce1, CompressedEntry const &ce2, LFT lenbound, std::vector<Entry>& transaction_db, LFT inner = 0., LFT new_l = 0., bool reduce_while_bucketing = true); // in bgj1_sieve.cpp
     #else
-    template <int tn>
-    inline bool bgj1_reduce_with_delayed_replace(CompressedEntry const &ce1, CompressedEntry const &ce2, LFT lenbound, std::vector<Entry>& transaction_db); // in bgj1_sieve.cpp
+    template <int tn, bool use_inner>
+    inline bool bgj1_reduce_with_delayed_replace(CompressedEntry const &ce1, CompressedEntry const &ce2, LFT lenbound, std::vector<Entry>& transaction_db, LFT inner = 0., LFT new_l = 0.); // in bgj1_sieve.cpp
     #endif
     // Tries to put pending transactions from transaction_db into the database.
     // Note that this can fail for various reasons: Points can be removed from transaction_db without inserting into db,


### PR DESCRIPTION
At the moment the bgj1 sieve computes inner products twice if ```bgj1_reduce_with_delayed_replace``` is called in the bucketing loop. 

This seems weird: it's possible for these values to be different (i.e if the database is updated in between the inner product computations), and it may also be inefficient.

This pull request is a (tentative) approach to fixing this. The changes are as follows:
a) There's two new parameters for ```bgj1_reduce_with_delayed_replace``` : ```LFT inner``` and ```LFT new_l```. These are the inner product and new length as computed in the bucketing loop.
A default value of ```0.``` is supplied for both in ```siever.h```.

b) change the template signature for ```bgj1_reduce_with_delayed_replace```. As opposed to the previous ```template <int tn> ``` signature, this PR adds an additional parameter ```use_inner```. 
No default is provided for this parameter: a default of ```false``` might be a good idea, and I'm happy to add this if it's preferred.

If ```use_inner``` is true, then we use the ```inner``` and ```new_l``` as passed in to the function. Otherwise, ```inner``` and ```new_l``` are computed as before.  

Additional considerations: this doesn't actually appear to improve performance at all -- as per usual, the basis quality appears far more important. 

I'm also happy to admit that adding the template parameter will increase compilation time, albeit a little bit. There may also be a more satisfactory solution -- happy to hear opinions! :) 