### PR TITLE
Fix building with bootstrap

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   JOBS: 2
-  DEPS: libgmp-dev libmpfr-dev libqd-dev libtool autoconf python3-pip python3-dev python3-flake8 python3-virtualenv
+  DEPS: libgmp-dev libmpfr-dev libqd-dev libtool autoconf python3-pip python3-dev python3-flake8
   
 jobs:
   python3:
@@ -25,6 +25,7 @@ jobs:
         run: |
           sudo DEBIAN_FRONTEND=noninteractive apt-get update
           sudo DEBIAN_FRONTEND=noninteractive apt-get install $DEPS
+          pip install virtualenv
       - name: Bootstrap
         run: ./bootstrap.sh
           

--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -1,0 +1,32 @@
+name: Bootstrap
+
+on: 
+  push:
+  pull_request:
+  schedule:
+    - cron: '0 0 * * 0' # weekly
+
+env:
+  JOBS: 2
+  DEPS: libgmp-dev libmpfr-dev libqd-dev libtool autoconf python3-pip python3-dev python3-flake8
+  
+jobs:
+  python3:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+             python-version: '3.x'        
+      - name: Check out
+        uses: actions/checkout@v2
+      - name: Install prerequisites
+        run: |
+          sudo DEBIAN_FRONTEND=noninteractive apt-get update
+          sudo DEBIAN_FRONTEND=noninteractive apt-get install $DEPS
+      - name: Bootstrap
+        run: ./bootstrap.sh
+          
+      - name: Test
+        run: python -m pytest

--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -30,6 +30,4 @@ jobs:
         run: ./bootstrap.sh
           
       - name: Test        
-        run: |
-          source ./activate
-          python -m pytest
+        run: source ./activate && python -m pytest

--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   JOBS: 2
-  DEPS: libgmp-dev libmpfr-dev libqd-dev libtool autoconf python3-pip python3-dev python3-flake8
+  DEPS: libgmp-dev libmpfr-dev libqd-dev libtool autoconf python3-pip python3-dev python3-flake8 python3-virtualenv
   
 jobs:
   python3:

--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -29,5 +29,7 @@ jobs:
       - name: Bootstrap
         run: ./bootstrap.sh
           
-      - name: Test
-        run: python -m pytest
+      - name: Test        
+        run: |
+          source ./activate
+          python -m pytest

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ stamp-h1
 /missing
 /ltmain.sh
 /libtool
+/test-driver

--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,7 @@ Otherwise, you will need fplll and fpylll already installed and build the G6K Cy
 
     pip install Cython
     pip install -r requirements.txt
-    python setup.py build [ -j # ]
+    python setup.py build_ext [ -j # ]
 
 It's possible to alter the C++ kernel build configuration as follows:
 
@@ -47,7 +47,7 @@ It's possible to alter the C++ kernel build configuration as follows:
     make clean
     ./configure [opts...]           # e.g. opts: --enable-native --enable-templated-dim --with-max-sieving-dim=128
                                     # see ./configure --help for more options
-    python setup.py build [ -j # ]
+    python setup.py build_ext [ -j # ]
 
 Tests
 =====

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -80,7 +80,7 @@ retval=$?
 if [ $retval -ne 0 ]; then
     echo "Make clean failed in fplll. This is usually because there was an error with either autogen.sh or configure."
     echo "Check the logs above - they'll contain more information."
-    exit 1 # 1 is the exit value if building fplll fails via configure or autogen
+    exit 1 # 1 is the exit value if build_exting fplll fails via configure or autogen
 fi
 
 make $jobs
@@ -88,7 +88,7 @@ retval=$?
 if [ $retval -ne 0 ]; then
     echo "Making fplll failed."
     echo "Check the logs above - they'll contain more information."
-    exit 2 # 2 is the exit value if building fplll fails as a result of make $jobs.
+    exit 2 # 2 is the exit value if build_exting fplll fails as a result of make $jobs.
 fi
 
 make install
@@ -109,13 +109,13 @@ $PIP install Cython
 $PIP install -r requirements.txt
 $PIP install -r suggestions.txt
 $PYTHON setup.py clean
-$PYTHON setup.py build $jobs || $PYTHON setup.py build
+$PYTHON setup.py build_ext $jobs || $PYTHON setup.py build_ext
 $PYTHON setup.py install
 cd ..
 
 $PIP install -r requirements.txt
 $PYTHON setup.py clean
-$PYTHON setup.py build $jobs --inplace || $PYTHON setup.py build --inplace
+$PYTHON setup.py build_ext $jobs --inplace || $PYTHON setup.py build_ext --inplace
 
 echo " "
 echo "Don't forget to activate environment each time:"

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -80,7 +80,7 @@ retval=$?
 if [ $retval -ne 0 ]; then
     echo "Make clean failed in fplll. This is usually because there was an error with either autogen.sh or configure."
     echo "Check the logs above - they'll contain more information."
-    exit 1 # 1 is the exit value if build_exting fplll fails via configure or autogen
+    exit 1 # 1 is the exit value if building fplll fails via configure or autogen
 fi
 
 make $jobs
@@ -88,7 +88,7 @@ retval=$?
 if [ $retval -ne 0 ]; then
     echo "Making fplll failed."
     echo "Check the logs above - they'll contain more information."
-    exit 2 # 2 is the exit value if build_exting fplll fails as a result of make $jobs.
+    exit 2 # 2 is the exit value if building fplll fails as a result of make $jobs.
 fi
 
 make install

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -21,7 +21,7 @@ echo "Using $jobs"
 sleep 1
 
 rm -rf g6k-env
-$PYTHON -m virtualenv g6k-env
+$PYTHON -m virtualenv g6k-env -p $PYTHON
 cat <<EOF >>g6k-env/bin/activate
 ### LD_LIBRARY_HACK
 _OLD_LD_LIBRARY_PATH="\$LD_LIBRARY_PATH"
@@ -103,6 +103,7 @@ fi
 cd ..
 
 # Install FPyLLL
+
 git clone https://github.com/fplll/fpylll g6k-fpylll
 cd g6k-fpylll || exit
 $PIP install Cython
@@ -113,9 +114,13 @@ $PYTHON setup.py build_ext $jobs || $PYTHON setup.py build_ext
 $PYTHON setup.py install
 cd ..
 
+# Build G6K
+
 $PIP install -r requirements.txt
 $PYTHON setup.py clean
 $PYTHON setup.py build_ext $jobs --inplace || $PYTHON setup.py build_ext --inplace
+
+# Fin
 
 echo " "
 echo "Don't forget to activate environment each time:"

--- a/rebuild.sh
+++ b/rebuild.sh
@@ -88,4 +88,4 @@ make -C kernel -j ${jobs} || exit 1
 
 rm -r build g6k/*.so `find g6k -name "*.pyc"`
 python setup.py clean
-python setup.py build -j ${jobs} --inplace || python setup.py build --inplace
+python setup.py build_ext -j ${jobs} --inplace || python setup.py build_ext --inplace


### PR DESCRIPTION
The version of bootstrap that's currently on the master branch gives the following error:

```
option --inplace not recognised
```

This appears to be related to the use of ```build```, rather than ```build_ext```. 
This PR fixes that bug.

