### PR TITLE
Provisional fix on the initialisation of the VLA.

### DIFF
--- a/kernel/fht_lsh.cpp
+++ b/kernel/fht_lsh.cpp
@@ -462,7 +462,17 @@ template<> void ProductLSH::hash_templated<3>(const float * const vv, int32_t * 
     //These arrays are temporaries that we use while inserting the hashes to res
     int32_t h0[multi_hash_block], h1[multi_hash_block], h2[multi_hash_block];
     float c0[multi_hash_block], c1[multi_hash_block], c2[multi_hash_block];
-    float c[multi_hash] = {0};
+    float c[multi_hash];
+
+    // This memset is inserted to prevent clang from complaining about initialising
+    // stack-allocated arrays. This is because stack-allocated arrays are a compiler extension
+    // and not endorsed by the C++ standard.
+
+    // Note that this call to memset actually appears to generate better code on more recent variants
+    // of gcc. In particular, the inline initialisation calls memset anyway, but it does more work
+    // in the pre-amble for setting up the stack-allocated array. See https://godbolt.org/z/vGh9c69br
+    // for an example. 
+    memset(&c, 0, sizeof(float)*multi_hash);    
 
     // Hash against the subcodes
     lshs[0].hash(&(vv[0]), c0, h0);
@@ -513,8 +523,12 @@ template<> void ProductLSH::hash_templated<2>(const float * const vv, int32_t * 
 {
     int32_t h0[multi_hash_block], h1[multi_hash_block];
     float c0[multi_hash_block], c1[multi_hash_block];
-    float c[multi_hash] = {0};
 
+    float c[multi_hash]; 
+    // This explicit memset is to prevent clang from complaining about initialising
+    // stack-allocated arrays. 
+    memset(&c, 0, sizeof(float)*multi_hash);
+    
     // Now hash against the two subcode blocks.
     lshs[0].hash(&(vv[0]), c0, h0);
     lshs[1].hash(&(vv[is[1]]), c1, h1);

--- a/kernel/fht_lsh.cpp
+++ b/kernel/fht_lsh.cpp
@@ -464,7 +464,7 @@ template<> void ProductLSH::hash_templated<3>(const float * const vv, int32_t * 
     float c0[multi_hash_block], c1[multi_hash_block], c2[multi_hash_block];
     float c[multi_hash];
 
-    // This memset is inserted to prevent clang from complaining about initialising
+    // This memset is inserted to prevent some compilers from complaining about initialising
     // stack-allocated arrays. This is because stack-allocated arrays are a compiler extension
     // and not endorsed by the C++ standard.
 
@@ -525,7 +525,7 @@ template<> void ProductLSH::hash_templated<2>(const float * const vv, int32_t * 
     float c0[multi_hash_block], c1[multi_hash_block];
 
     float c[multi_hash]; 
-    // This explicit memset is to prevent clang from complaining about initialising
+    // This explicit memset is to prevent some compilers from complaining about initialising
     // stack-allocated arrays. 
     memset(&c, 0, sizeof(float)*multi_hash);
     


### PR DESCRIPTION
This PR is meant to fix issue #89. In particular, the PR replaces the explicit initialisation with a memset. 

This is necessary because:
a) Stack-allocated arrays are not standard C++. Instead, these are provided by the compiler.
b) Older versions of GCC (i.e 4.7 and prior) don't support initialisation via ``=``. Clang -- although not explicitly supported by G6K -- doesn't allow this at all. This can be circumvented with a memset.

Note that this should not degrade performance in any manner. Indeed, the link in the comment shows that GCC calls memset on the variably allocated array anyway: this is just more explicit. 