### PR TITLE
Fix DeprecationWarning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ def read_from(filename, field, sep):
 
 with open(os.path.join("g6k", "__init__.py")) as f:
     __version__ = (
-        parse(next(filter(lambda line: line.startswith("__version__"), f))).body[0].value.s
+        parse(next(filter(lambda line: line.startswith("__version__"), f))).body[0].value.value
     )
 
 extra_compile_args = ["-std=c++11"]


### PR DESCRIPTION
g6k/setup.py:79: DeprecationWarning: Attribute s is deprecated and will be removed in Python 3.14; use value instead