### PR TITLE
Remove deprecated pkg_resource

### DIFF
--- a/g6k/siever_params.pyx
+++ b/g6k/siever_params.pyx
@@ -4,7 +4,7 @@ Sieving parameters.
 """
 
 from contextlib import contextmanager
-from pkg_resources import resource_filename
+from importlib.resources import as_file, files
 from decl cimport MAX_SIEVING_DIM
 
 import warnings
@@ -127,9 +127,8 @@ cdef class SieverParams(object):
         if "gauss_crossover" not in kwds:
             kwds["gauss_crossover"] = 50
         if "simhash_codes_basedir" not in kwds:
-            fname = resource_filename("g6k", "spherical_coding").encode()
-            if fname is None:
-                fname = b"./spherical_coding"
+            with as_file(files("g6k").joinpath("spherical_coding")) as f:
+                fname = str(f.absolute()) if f.exists() else "./spherical_coding"
             kwds["simhash_codes_basedir"] = fname
 
         read_only = False


### PR DESCRIPTION
Currently, when starting G6K, you get the following warning:
```
>>> from g6k import Siever
/export/scratch1/home/lnp/software/g6k/g6k/__init__.py:23: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
  from .siever_params import SieverParams  # noqa
```
So this PR removes using pkg_resources, and tries to find "g6k/spherical_coding" using importlib. Encoding the filename as utf-8 is deferred to `_set`, when it's passed to the C++ layer.

Note: I did not test this except checking that the absolute path is passed along (I don't know how to run the simhash stuff).